### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jtcohen6 @jasnonaz @eliasdefaria @akbog @schulte-lukas @wolfram-s
+* @dbt-labs/team-fs


### PR DESCRIPTION
### Problem

We have a list of individuals listed as codeowners, which isn't scalable.

### Solution

Update to a team name as codeowners.

PR author will need to designate reviewer(s).