### PR TITLE
Bump codeowners-validator action version

### DIFF
--- a/.github/workflows/codeowners-check.yml
+++ b/.github/workflows/codeowners-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: mszostok/codeowners-validator@v0.7.2
+      - uses: mszostok/codeowners-validator@v0.7.4
         with:
           github_access_token: "${{ secrets.OWNERS_VALIDATOR_GITHUB_SECRET }}"
           checks: "owners,duppatterns"


### PR DESCRIPTION
Resolves: #75 .

This PR fixes some bugs in the Github workflow.