### PR TITLE
Remove target date for Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Legend:
 | Operating System    | X86-64 | ARM  |
 |-------------------|----------|------|
 | MacOS             |   🟢     |  🟢  |
-| Linux             |   🟢     |  🟡  |
+| Linux             |   🟢     |  🟢  |
 | Windows           |   🟡     |  🟡  |
 
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Fusion & associated drivers are compiled for each CPU microarchitecture and oper
 
 Legend:
 * 🟢 - Supported today
-* 🟡 - Unsupported today, in progress & will be supported by 2025-07-18
+* 🟡 - Unsupported today
 
 | Operating System    | X86-64 | ARM  |
 |-------------------|----------|------|


### PR DESCRIPTION
We still intend to support for Windows in the near future, but we would rather remove this target date rather than have the date slip on us.

There are several things we'd need to fix to establish Windows support, and we need the space to be able to trade it off against other issues that might be higher priority to support / fix.