### PR TITLE
Adjust target timelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Legend:
 |-------------|-----------------------------|----------------------------------------------|
 | 2025-05-28  | Initial release of Fusion   | Published source code of parser, schemas, dbt-jinja, and Snowflake ADBC driver. |
 | 2025-06-09  | Databricks Adapter release  | Databricks ADBC driver, and adapter for Fusion |
-| 2025-06-25  | BigQuery Adapter release    | BigQuery ADBC driver, and adapter for Fusion |
-| 2025-07-09  | Redshift Adapter release    | Redshift ADBC driver, and adapter for Fusion |
-| 2025-07-18  | ANTLR Grammars release + SQL Parser  | The SQL grammar used by the ANTLR parser generator.  |
+| 2025-06-30  | BigQuery Adapter release    | BigQuery ADBC driver, and adapter for Fusion |
+| 2025-07-31  | Redshift Adapter release    | Redshift ADBC driver, and adapter for Fusion |
+| 2025-08-30  | ANTLR Grammars release + SQL Parser  | The SQL grammar used by the ANTLR parser generator.  |
 
 ### Top Level Components Released to Date
 Releases of various Fusion components will be iterative as each component reaches maturity & readiness for contribution.


### PR DESCRIPTION
Adjusting timelines due to some complexities with BigQuery and Redshift drivers (e.g. seeds for BigQuery, IAM auth for Redshift, etc).

We anticipate that we'll add both `bigquery` and `redshift` as options within the `dbt init` options prior to these dates as much of the functionality may land sooner than these target dates.