### PR TITLE
Run tests modifying DBT_ENV_PRIVATE_GIT_PROVIDER_INFO sequentially

### DIFF
--- a/crates/dbt-deps/src/private_package.rs
+++ b/crates/dbt-deps/src/private_package.rs
@@ -116,7 +116,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_private_packages() {
+    fn tests() {
+        // Run the tests sequentially to avoid flakyness when running in parallel due to
+        // manipulation of the DBT_ENV_PRIVATE_GIT_PROVIDER_INFO environment variable.
+        assert_private_packages();
+        assert_local_private_packages_github();
+        assert_local_private_packages_gitlab();
+        assert_local_private_packages_azure();
+        assert_local_private_packages_error();
+    }
+
+    fn assert_private_packages() {
         // Test get_provider_info()
         let json_provider_str = r#"
             [
@@ -152,8 +162,7 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_local_private_packages_github() {
+    fn assert_local_private_packages_github() {
         // Make sure the variable is not set as we want to simulate a local run.
         #[allow(clippy::disallowed_methods)]
         std::env::remove_var("DBT_ENV_PRIVATE_GIT_PROVIDER_INFO");
@@ -174,8 +183,7 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_local_private_packages_gitlab() {
+    fn assert_local_private_packages_gitlab() {
         // Make sure the variable is not set as we want to simulate a local run.
         #[allow(clippy::disallowed_methods)]
         std::env::remove_var("DBT_ENV_PRIVATE_GIT_PROVIDER_INFO");
@@ -198,8 +206,8 @@ mod tests {
                 .to_string()
         );
     }
-    #[test]
-    fn test_local_private_packages_azure() {
+
+    fn assert_local_private_packages_azure() {
         // Make sure the variable is not set as we want to simulate a local run.
         #[allow(clippy::disallowed_methods)]
         std::env::remove_var("DBT_ENV_PRIVATE_GIT_PROVIDER_INFO");
@@ -222,8 +230,7 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_local_private_packages_error() {
+    fn assert_local_private_packages_error() {
         // Make sure the variable is not set as we want to simulate a local run.
         #[allow(clippy::disallowed_methods)]
         std::env::remove_var("DBT_ENV_PRIVATE_GIT_PROVIDER_INFO");


### PR DESCRIPTION
Fixes https://github.com/dbt-labs/dbt-fusion/issues/353.

Another alternative to keep the tests as normal tests is to use a mutex (possibly as a macro, as in https://github.com/Thomasdezeeuw/std-logger/blob/17fd34131a1b71063139e393de949a54990b2ef8/src/tests.rs#L14-L33).