### PR TITLE
Change bigquery job_*_seconds types from string to int

### DIFF
--- a/.changes/unreleased/Fixes-20250713-041642.yaml
+++ b/.changes/unreleased/Fixes-20250713-041642.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: '[Bigquery] Change Change bigquery job_*_seconds types from string to int'
+time: 2025-07-13T04:16:42.288502+02:00

--- a/crates/dbt-schemas/src/schemas/profiles.rs
+++ b/crates/dbt-schemas/src/schemas/profiles.rs
@@ -569,10 +569,10 @@ pub struct BigqueryDbConfig {
     pub dataproc_cluster_name: Option<String>,
     pub dataproc_region: Option<String>,
     pub gcs_bucket: Option<String>,
-    pub job_creation_timeout_seconds: Option<String>,
-    pub job_execution_timeout_seconds: Option<String>,
+    pub job_creation_timeout_seconds: Option<i64>,
+    pub job_execution_timeout_seconds: Option<i64>,
     pub job_retries: Option<i64>,
-    pub job_retry_deadline_seconds: Option<String>,
+    pub job_retry_deadline_seconds: Option<i64>,
     pub target_name: Option<String>,
 
     #[serde(flatten)]
@@ -710,10 +710,10 @@ pub struct BigqueryTargetEnv {
     pub execution_project: Option<String>,
     pub gcs_bucket: Option<String>,
     pub impersonate_service_account: Option<String>,
-    pub job_creation_timeout_seconds: Option<String>,
-    pub job_execution_timeout_seconds: Option<String>,
+    pub job_creation_timeout_seconds: Option<i64>,
+    pub job_execution_timeout_seconds: Option<i64>,
     pub job_retries: Option<i64>,
-    pub job_retry_deadline_seconds: Option<String>,
+    pub job_retry_deadline_seconds: Option<i64>,
     pub location: Option<String>,
     pub maximum_bytes_billed: Option<i64>,
     pub method: Option<String>,
@@ -864,10 +864,10 @@ impl TryFrom<DbConfig> for TargetContext {
                     execution_project: config.execution_project.clone(),
                     gcs_bucket: config.gcs_bucket.clone(),
                     impersonate_service_account: config.impersonate_service_account.clone(),
-                    job_creation_timeout_seconds: config.job_creation_timeout_seconds.clone(),
-                    job_execution_timeout_seconds: config.job_execution_timeout_seconds.clone(),
+                    job_creation_timeout_seconds: config.job_creation_timeout_seconds,
+                    job_execution_timeout_seconds: config.job_execution_timeout_seconds,
                     job_retries: config.job_retries,
-                    job_retry_deadline_seconds: config.job_retry_deadline_seconds.clone(),
+                    job_retry_deadline_seconds: config.job_retry_deadline_seconds,
                     location: config.location.clone(),
                     maximum_bytes_billed: config.maximum_bytes_billed,
                     method: config.method.clone(),
@@ -941,5 +941,23 @@ mod tests {
 
         assert_eq!(config.get_unique_field(), None);
         assert_eq!(config.get_adapter_unique_id(), None);
+    }
+
+    #[test]
+    fn test_bigquery_adapter_config_parsing() {
+        let config: DbConfig = dbt_serde_yaml::from_str(
+            "type: bigquery\n\
+             job_creation_timeout_seconds: 123\n\
+             job_execution_timeout_seconds: 456\n\
+             job_retry_deadline_seconds: 789",
+        )
+        .unwrap();
+        if let DbConfig::Bigquery(bigquery_config) = config {
+            assert_eq!(bigquery_config.job_creation_timeout_seconds, Some(123));
+            assert_eq!(bigquery_config.job_execution_timeout_seconds, Some(456));
+            assert_eq!(bigquery_config.job_retry_deadline_seconds, Some(789));
+        } else {
+            panic!("Expected DbConfig::Bigquery, got {:?}", config);
+        }
     }
 }


### PR DESCRIPTION
Fix the parsing error noted in https://github.com/dbt-labs/dbt-fusion/issues/221#issuecomment-3062773168.

Before this change `profiles.yml` configuration such as the below is rejected by fusion (while core allows it):

```yml
      job_creation_timeout_seconds: 123
      job_execution_timeout_seconds: 456  
      job_retry_deadline_seconds: 789
```