### PR TITLE
Support overriding the dbt package hub url using DBT_PACKAGE_HUB_URL

### DIFF
--- a/.changes/unreleased/Features-20250713-232947.yaml
+++ b/.changes/unreleased/Features-20250713-232947.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Support overriding the dbt package hub url using DBT_PACKAGE_HUB_URL
+time: 2025-07-13T23:29:47.54001+02:00

--- a/crates/dbt-deps/src/mod.rs
+++ b/crates/dbt-deps/src/mod.rs
@@ -35,7 +35,19 @@ pub async fn get_or_install_packages(
     add_package: Option<String>,
     vars: BTreeMap<String, dbt_serde_yaml::Value>,
 ) -> FsResult<(DbtPackagesLock, Vec<UpstreamProject>)> {
-    let mut hub_registry = HubClient::new(DBT_HUB_URL);
+    let hub_url_from_env = std::env::var("DBT_PACKAGE_HUB_URL");
+    let hub_url = hub_url_from_env
+        .as_deref()
+        .map(|s| {
+            if s.ends_with('/') {
+                // dbt-core required a trailing slash - here we support but do not require it.
+                &s[0..s.len() - 1]
+            } else {
+                s
+            }
+        })
+        .unwrap_or(DBT_HUB_URL);
+    let mut hub_registry = HubClient::new(hub_url);
 
     let package_render_scope = RenderSecretScope::new(env, vars);
 


### PR DESCRIPTION
Fixes https://github.com/dbt-labs/dbt-fusion/issues/152.