### PR TITLE
Allow hours, minutes and seconds format codes in `PyDate::strftime()`

### DIFF
--- a/.changes/unreleased/Fixes-20250727-202944.yaml
+++ b/.changes/unreleased/Fixes-20250727-202944.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Allow hours, minutes and seconds format codes in strftime() on a date
+time: 2025-07-27T20:29:44.167208+02:00


### PR DESCRIPTION
Make `PyDate::strftime()` behave like python when formatting hours, minutes and seconds.

See [datetime.date.strftime](https://docs.python.org/3/library/datetime.html#datetime.date.strftime):

> Format codes referring to hours, minutes or seconds will see 0 values

Fixes https://github.com/dbt-labs/dbt-fusion/issues/442.