### PR TITLE
Make `re.sub()` support python style backslash backreferences

### DIFF
--- a/.changes/unreleased/Fixes-20250728-135348.yaml
+++ b/.changes/unreleased/Fixes-20250728-135348.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Make re.sub() support python style backslash backreferences
+time: 2025-07-28T13:53:48.758396+02:00


### PR DESCRIPTION
Configure `fancy-regex` to expand python style backslash backreferences like `\1` and `\2` instead of the default `$` substitution character.

Fixes https://github.com/dbt-labs/dbt-fusion/issues/86.