### PR TITLE
Support service account impersonation for BigQuery auth

### DIFF
--- a/crates/dbt-common/src/profile_setup.rs
+++ b/crates/dbt-common/src/profile_setup.rs
@@ -381,6 +381,35 @@ impl ProfileSetup {
                     "method".to_string(),
                     serde_json::Value::String("oauth".to_string()),
                 );
+
+                let impersonate: bool = Confirm::new()
+                    .with_prompt("Do you want to impersonate a service account?")
+                    .default(false)
+                    .interact()
+                    .map_err(|e| {
+                        fs_err!(
+                            ErrorCode::IoError,
+                            "Failed to get impersonation choice: {}",
+                            e
+                        )
+                    })?;
+
+                if impersonate {
+                    let impersonate_service_account: String = Input::new()
+                        .with_prompt("impersonate_service_account (dbt-runner@your-project.iam.gserviceaccount.com)")
+                        .interact_text()
+                        .map_err(|e| {
+                            fs_err!(
+                                ErrorCode::IoError,
+                                "Failed to get impersonate_service_account: {}",
+                                e
+                            )
+                        })?;
+                    config.insert(
+                        "impersonate_service_account".to_string(),
+                        serde_json::Value::String(impersonate_service_account),
+                    );
+                }
             }
             1 => {
                 config.insert(

--- a/crates/dbt-fusion-adapter/src/bigquery/auth.rs
+++ b/crates/dbt-fusion-adapter/src/bigquery/auth.rs
@@ -1,0 +1,24 @@
+use crate::auth::Auth;
+use crate::config::AdapterConfig;
+use crate::errors::AdapterResult;
+use dbt_xdbc::{database, Backend};
+
+pub(crate) struct BigQueryAuth;
+
+impl Auth for BigQueryAuth {
+    fn backend(&self) -> Backend {
+        Backend::BigQuery
+    }
+
+    fn configure(&self, config: &AdapterConfig) -> AdapterResult<database::Builder> {
+        let mut builder = database::Builder::new(self.backend());
+
+        if let Ok(impersonate_principal) = config.get_str("impersonate_service_account") {
+            builder.with_named_option(
+                dbt_xdbc::bigquery::IMPERSONATE_TARGET_PRINCIPAL,
+                impersonate_principal,
+            )?;
+        }
+        Ok(builder)
+    }
+}

--- a/crates/dbt-fusion-adapter/src/bigquery/mod.rs
+++ b/crates/dbt-fusion-adapter/src/bigquery/mod.rs
@@ -1,3 +1,5 @@
+/// Bigquery auth
+pub(crate) mod auth;
 /// Databricks formatter
 pub(crate) mod formatter;
 /// Bigquery relation

--- a/crates/dbt-xdbc/src/bigquery.rs
+++ b/crates/dbt-xdbc/src/bigquery.rs
@@ -51,6 +51,7 @@ pub const QUERY_JOB_TIMEOUT: &str = "adbc.bigquery.sql.query.job_timeout"; // i6
 
 pub const QUERY_RESULT_BUFFER_SIZE: &str = "adbc.bigquery.sql.query.result_buffer_size"; // i64
 pub const QUERY_PREFETCH_CONCURRENCY: &str = "adbc.bigquery.sql.query.prefetch_concurrency"; // i64
+pub const IMPERSONATE_TARGET_PRINCIPAL: &str = "adbc.bigquery.sql.impersonate.target_principal";
 
 // values
 pub const DEFAULT_QUERY_RESULT_BUFFER_SIZE: i64 = 200;


### PR DESCRIPTION
Solves https://github.com/dbt-labs/dbt-fusion/issues/409

## NOTE

We have supported service account impersonation in arrow-adbc. It isn't released yet. I am just checking when the next release is.

https://github.com/apache/arrow-adbc/pull/3174