### PR TITLE
Creating workflow to open docs issue with need-docs label 

### DIFF
--- a/.github/workflows/docs-label.yaml
+++ b/.github/workflows/docs-label.yaml
@@ -5,7 +5,7 @@ run-name: "Create an issue in docs-internal for PR #${{ github.event.pull_reques
 
 on:
   pull_request_target:
-    types: [closed]
+    types: [labeled, closed]
 
 permissions:
   issues: write


### PR DESCRIPTION
Adding a workflow with automation that opens an issue in the dbt-labs/docs-internal repo when the `needs-docs` label is used on a pull request. The docs team will get notified when this is opened and work to document your change.

[Slack message](https://dbt-labs.slack.com/archives/C050UR03P46/p1752262067833129) with more info
Notion [doc with details](https://www.notion.so/dbtlabs/Using-needs-docs-for-bug-fixes-225bb38ebda780498d22cc267d136ab5#225bb38ebda7800fa2a4eecd99a3edb8) and problem this is solving.