### PR TITLE
minijinja: Make `modules.re.match()` return a truthy value on a match

### DIFF
--- a/.changes/unreleased/Fixes-20250815-155849.yaml
+++ b/.changes/unreleased/Fixes-20250815-155849.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Make modules.re.match() return a truthy value on a match
+time: 2025-08-15T15:58:49.024187+02:00


### PR DESCRIPTION
Fixes https://github.com/dbt-labs/dbt-fusion/issues/560.