### PR TITLE
Render booleans as `True`/`False` instead of `true`/`false`

### DIFF
--- a/.changes/unreleased/Fixes-20250824-223749.yaml
+++ b/.changes/unreleased/Fixes-20250824-223749.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Render booleans as True/False instead of true/false
+time: 2025-08-24T22:37:49.516614+02:00

--- a/crates/dbt-jinja/minijinja/src/value/mod.rs
+++ b/crates/dbt-jinja/minijinja/src/value/mod.rs
@@ -673,7 +673,7 @@ impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
             ValueRepr::Undefined => Ok(()),
-            ValueRepr::Bool(val) => val.fmt(f),
+            ValueRepr::Bool(val) => write!(f, "{}", if *val { "True" } else { "False" }),
             ValueRepr::U64(val) => val.fmt(f),
             ValueRepr::I64(val) => val.fmt(f),
             ValueRepr::F64(val) => {

--- a/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@coerce.txt.snap
+++ b/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@coerce.txt.snap
@@ -1,22 +1,30 @@
 ---
-source: fs/sa/crates/dbt-jinja/minijinja/tests/test_templates.rs
+source: crates/dbt-jinja/minijinja/tests/test_templates.rs
 description: "{{ \"World\"[0] == \"W\" }}\n{{ \"W\" == \"W\" }}\n{{ 1.0 == 1 }}\n{{ 1 != 2 }}\n{{ none == none }}\n{{ undefined == undefined }}\n{{ true == true }}\n{{ 1 == true }}\n{{ 0 == false }}\n{{ 1 != 0 }}\n{{ \"a\" < \"b\" }}\n{{ \"a\"[0] < \"b\" }}\n{{ false < true }}\n{{ 0 < true }}\n{{ [0, 0] == [0, 0] }}\n{{ [\"a\"] == [\"a\"[0]] }}"
-info: {}
-input_file: fs/sa/crates/dbt-jinja/minijinja/tests/inputs/coerce.txt
+info:
+  __minijinja_current_path: coerce.txt
+  __minijinja_current_span:
+    end_col: 1
+    end_line: 1
+    end_offset: 0
+    start_col: 1
+    start_line: 1
+    start_offset: 0
+input_file: crates/dbt-jinja/minijinja/tests/inputs/coerce.txt
 ---
-true
-true
-true
-true
-true
-true
-true
-true
-true
-true
-true
-true
-true
-false
-true
-true
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+False
+True
+True

--- a/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@filters.txt.snap
+++ b/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@filters.txt.snap
@@ -1,5 +1,5 @@
 ---
-source: fs/sa/crates/dbt-jinja/minijinja/tests/test_templates.rs
+source: crates/dbt-jinja/minijinja/tests/test_templates.rs
 description: "lower: {{ word|lower }}\nupper: {{ word|upper }}\ntitle: {{ word|title }}\ntitle-sentence: {{ \"the bIrd, is The:word\"|title }}\ntitle-three-words: {{ three_words|title }}\ncapitalize: {{ word|capitalize }}\ncapitalize-three-words: {{ three_words|capitalize }}\nreplace: {{ word|replace(\"B\", \"th\") }}\nreplace: {{ \"DW_test\" | replace(\"DW_\", \"\", 1)}}\nescape: {{ \"<\"|escape }}\ne: {{ \"<\"|e }}\ndouble-escape: {{ \"<\"|escape|escape }}\nsafe: {{ \"<\"|safe|escape }}\nlist-length: {{ list|length }}\nlist-from-list: {{ list|list }}\nlist-from-map: {{ map|list }}\nlist-from-word: {{ word|list }}\nlist-from-undefined: {{ undefined|list }}\nbool-empty-string: {{ \"\"|bool }}\nbool-non-empty-string: {{ \"hello\"|bool }}\nbool-empty-list: {{ []|bool }}\nbool-non-empty-list: {{ [42]|bool }}\nbool-undefined: {{ undefined|bool }}\nmap-length: {{ map|length }}\nstring-length: {{ word|length }}\nstring-count: {{ word|count }}\nreverse-list: {{ list|reverse }}\nreverse-string: {{ word|reverse }}\ntrim: |{{ word_with_spaces|trim }}|\ntrim-bird: {{ word|trim(\"Bd\") }}\njoin-default: {{ list|join }}\njoin-pipe: {{ list|join(\"|\") }}\njoin_string: {{ word|join('-') }}\ndefault: {{ undefined|default == \"\" }}\ndefault-value: {{ undefined|default(42) }}\nfirst-list: {{ list|first }}\nfirst-word: {{ word|first }}\nfirst-undefined: {{ []|first is undefined }}\nlast-list: {{ list|last }}\nlast-word: {{ word|last }}\nlast-undefined: {{ []|first is undefined }}\nmin: {{ other_list|min }}\nmax: {{ other_list|max }}\nsort: {{ other_list|sort }}\nsort-reverse: {{ other_list|sort(reverse=true) }}\nsort-case-insensitive: {{ [\"B\", \"a\", \"C\", \"z\"]|sort }}\nsort-case-sensitive: {{ [\"B\", \"a\", \"C\", \"z\"]|sort(case_sensitive=true) }}\nsort-case-insensitive-mixed: {{ [0, 1, \"true\", \"false\", \"True\", \"False\", true, false]|sort }}\nsort-case-sensitive-mixed: {{ [0, 1, \"true\", \"false\", \"True\", \"False\", true, false]|sort(case_sensitive=true) }}\nsort-attribute {{ objects|sort(attribute=\"name\") }}\nd: {{ undefined|d == \"\" }}\njson: {{ map|tojson }}\njson-pretty: {{ map|tojson(true) }}\njson-scary-html: {{ scary_html|tojson }}\nurlencode: {{ \"hello world/foo-bar_baz.txt\"|urlencode }}\nurlencode-kv: {{ dict(a=\"x y\", b=2, c=3, d=None)|urlencode }}\nbatch: {{ range(10)|batch(3) }}\nbatch-fill: {{ range(10)|batch(3, '-') }}\nslice: {{ range(10)|slice(3) }}\nslice-fill: {{ range(10)|slice(3, '-') }}\nitems: {{ dict(a=1)|items }}\nindent: {{ \"foo\\nbar\\nbaz\"|indent(2)|tojson }}\nindent-first-line: {{ \"foo\\nbar\\nbaz\"|indent(2, true)|tojson }}\nint-abs: {{ -42|abs }}\nfloat-abs: {{ -42.5|abs }}\nint-round: {{ 42|round }}\nfloat-round: {{ 42.5|round }}\nfloat-round-prec2: {{ 42.512345|round(2) }}\nfloat-round-ceil: {{ 42.512345|round(0, 'ceil') }}\nfloat-round-floor: {{ 42.512345|round(0, 'floor') }}\nfloat-round-common: {{ 42.512345|round(0, 'common') }}\nselect-odd: {{ [1, 2, 3, 4, 5, 6]|select(\"odd\") }}\nselect-truthy: {{ [undefined, null, 0, 42, 23, \"\", \"aha\"]|select }}\nreject-truthy: {{ [undefined, null, 0, 42, 23, \"\", \"aha\"]|reject }}\nreject-odd: {{ [1, 2, 3, 4, 5, 6]|reject(\"odd\") }}\nselect-attr: {{ [dict(active=true, key=1), dict(active=false, key=2)]|selectattr(\"active\") }}\nreject-attr: {{ [dict(active=true, key=1), dict(active=false, key=2)]|rejectattr(\"active\") }}\nselect-attr: {{ [dict(active=true, key=1), dict(active=false, key=2)]|selectattr(\"key\", \"even\") }}\nreject-attr: {{ [dict(active=true, key=1), dict(active=false, key=2)]|rejectattr(\"key\", \"even\") }}\nmap-maps: {{ [-1, -2, 3, 4, -5]|map(\"abs\") }}\nmap-attr: {{ [dict(a=1), dict(a=2), {}]|map(attribute='a', default=None) }}\nmap-attr-undefined: {{ [dict(a=1), dict(a=2), {}]|map(attribute='a', default=definitely_undefined) }}\nmap-attr-deep: {{ [dict(a=[1]), dict(a=[2]), dict(a=[])]|map(attribute='a.0', default=None) }}\nmap-attr-int: {{ [[1], [1, 2]]|map(attribute=1, default=999) }}\nattr-filter: {{ map|attr(\"a\") }}\nunique-filter: {{ [1, 1, 1, 4, 3, 0, 0, 5]|unique }}\nunique-filter-ci: {{ [\"a\", \"A\", \"b\", \"c\", \"b\", \"D\", \"d\"]|unique }}\nunique-filter-cs: {{ [\"a\", \"A\", \"b\", \"c\", \"b\", \"D\", \"d\"]|unique(case_sensitive=true) }}\nunique-attr-filter: {{ [{'x': 1}, {'x': 1, 'y': 2}, {'x': 2}]|unique }}\npprint-filter: {{ objects|pprint }}\nint-filter: {{ true|int }}, {{ \"42\"|int }}, {{ \"-23\"|int }}, {{ 42.0|int }}, {{ 42.42|int }}, {{ \"42.42\"|int }}\nfloat-filter: {{ true|float }}, {{ \"42\"|float }}, {{ \"-23.5\"|float }}, {{ 42.5|float }}\nsplit: {{ three_words|split|list }}\nsplit-at-and: {{ three_words|split(\" and \")|list }}\nsplit-n-ws: {{ three_words|split(none, 1)|list }}\nsplit-n-d: {{ three_words|split(\"d\", 1)|list }}\nsplit-n-ws-filter-empty: {{ \"  foo    bar baz  \"|split(none, 1)|list }}\nsum: {{ range(10)|sum }}\nsum-empty: {{ []|sum }}\nsum-float: {{ [0.5, 1.0]|sum }}\nlines: {{ \"foo\\nbar\\r\\nbaz\"|lines }}\nstring: {{ [1|string, 2|string] }}"
 info:
   __minijinja_current_path: filters.txt
@@ -30,7 +30,7 @@ info:
   three_words: bird and dinosaur
   word: Bird
   word_with_spaces: " Spacebird\n"
-input_file: fs/sa/crates/dbt-jinja/minijinja/tests/inputs/filters.txt
+input_file: crates/dbt-jinja/minijinja/tests/inputs/filters.txt
 ---
 lower: bird
 upper: BIRD
@@ -50,11 +50,11 @@ list-from-list: [1, 2, 3]
 list-from-map: ['a', 'c']
 list-from-word: ['B', 'i', 'r', 'd']
 list-from-undefined: []
-bool-empty-string: false
-bool-non-empty-string: true
-bool-empty-list: false
-bool-non-empty-list: true
-bool-undefined: false
+bool-empty-string: False
+bool-non-empty-string: True
+bool-empty-list: False
+bool-non-empty-list: True
+bool-undefined: False
 map-length: 2
 string-length: 4
 string-count: 4
@@ -65,14 +65,14 @@ trim-bird: ir
 join-default: 123
 join-pipe: 1|2|3
 join_string: B-i-r-d
-default: true
+default: True
 default-value: 42
 first-list: 1
 first-word: B
-first-undefined: true
+first-undefined: True
 last-list: 3
 last-word: d
-last-undefined: true
+last-undefined: True
 min: 1
 max: 111
 sort: (1, 2, 4, 9, 111)
@@ -82,7 +82,7 @@ sort-case-sensitive: ('B', 'C', 'a', 'z')
 sort-case-insensitive-mixed: (false, true, 0, 1, 'false', 'False', 'true', 'True')
 sort-case-sensitive-mixed: (false, true, 0, 1, 'False', 'True', 'false', 'true')
 sort-attribute ({'name': 'a'}, {'name': 'b'})
-d: true
+d: True
 json: {"a":"b","c":"d"}
 json-pretty: {
   "a": "b",

--- a/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@functions.txt.snap
+++ b/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@functions.txt.snap
@@ -1,9 +1,17 @@
 ---
 source: crates/dbt-jinja/minijinja/tests/test_templates.rs
 description: "short-range: {{ range(10) }}\nrange-is-iterable: {{ range(10) is iterable }}\nrange-is-not-a-sequence: {{ range(10) is not sequence }}"
-info: {}
+info:
+  __minijinja_current_path: functions.txt
+  __minijinja_current_span:
+    end_col: 1
+    end_line: 1
+    end_offset: 0
+    start_col: 1
+    start_line: 1
+    start_offset: 0
 input_file: crates/dbt-jinja/minijinja/tests/inputs/functions.txt
 ---
 short-range: (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-range-is-iterable: true
-range-is-not-a-sequence: true
+range-is-iterable: True
+range-is-not-a-sequence: True

--- a/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@getattr.txt.snap
+++ b/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@getattr.txt.snap
@@ -1,12 +1,19 @@
 ---
-source: minijinja/tests/test_templates.rs
+source: crates/dbt-jinja/minijinja/tests/test_templates.rs
 description: "name: {{ user.name }}\nactive: {{ user.is_active }}"
 info:
+  __minijinja_current_path: getattr.txt
+  __minijinja_current_span:
+    end_col: 1
+    end_line: 1
+    end_offset: 0
+    start_col: 1
+    start_line: 1
+    start_offset: 0
   user:
     is_active: true
     name: Peter
-input_file: minijinja/tests/inputs/getattr.txt
+input_file: crates/dbt-jinja/minijinja/tests/inputs/getattr.txt
 ---
 name: Peter
-active: true
-
+active: True

--- a/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@ifexpr.txt.snap
+++ b/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@ifexpr.txt.snap
@@ -1,12 +1,19 @@
 ---
-source: minijinja/tests/test_templates.rs
+source: crates/dbt-jinja/minijinja/tests/test_templates.rs
 description: "{{ 42 if something_true else 23 }}\n{{ 42 if not something_true else 23 }}\n{{ 42 if not something_true }}\n{{ (42 if not something_true) is undefined }}"
 info:
+  __minijinja_current_path: ifexpr.txt
+  __minijinja_current_span:
+    end_col: 1
+    end_line: 1
+    end_offset: 0
+    start_col: 1
+    start_line: 1
+    start_offset: 0
   something_true: true
-input_file: minijinja/tests/inputs/ifexpr.txt
+input_file: crates/dbt-jinja/minijinja/tests/inputs/ifexpr.txt
 ---
 42
 23
 
-true
-
+True

--- a/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@in.txt.snap
+++ b/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@in.txt.snap
@@ -1,7 +1,15 @@
 ---
-source: minijinja/tests/test_templates.rs
+source: crates/dbt-jinja/minijinja/tests/test_templates.rs
 description: "{{ word in the_sentence }}\n{{ word in the_words }}\n{{ word in the_map }}\n{{ word not in the_sentence }}\n{{ word not in the_words }}\n{{ word not in the_map }}"
 info:
+  __minijinja_current_path: in.txt
+  __minijinja_current_span:
+    end_col: 1
+    end_line: 1
+    end_offset: 0
+    start_col: 1
+    start_line: 1
+    start_offset: 0
   the_map:
     bird: the word
   the_sentence: bird is the word
@@ -9,12 +17,11 @@ info:
     - bird
     - not bird
   word: bird
-input_file: minijinja/tests/inputs/in.txt
+input_file: crates/dbt-jinja/minijinja/tests/inputs/in.txt
 ---
-true
-true
-true
-false
-false
-false
-
+True
+True
+True
+False
+False
+False

--- a/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@indexing.txt.snap
+++ b/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@indexing.txt.snap
@@ -1,8 +1,16 @@
 ---
-source: minijinja/tests/test_templates.rs
+source: crates/dbt-jinja/minijinja/tests/test_templates.rs
 description: "{{ hello[0] }}\n{{ hello[3] }}\n{{ hello[-1] }}\n{{ hello[999] is undefined }}\n{{ intrange[0] }}\n{{ intrange[3] }}\n{{ intrange[-1] }}\n{{ intrange[999] is undefined }}"
 info:
-  hello: Hello World
+  __minijinja_current_path: indexing.txt
+  __minijinja_current_span:
+    end_col: 1
+    end_line: 1
+    end_offset: 0
+    start_col: 1
+    start_line: 1
+    start_offset: 0
+  hello: Hällo Wörld
   intrange:
     - 0
     - 1
@@ -14,14 +22,13 @@ info:
     - 7
     - 8
     - 9
-input_file: minijinja/tests/inputs/indexing.txt
+input_file: crates/dbt-jinja/minijinja/tests/inputs/indexing.txt
 ---
 H
 l
 d
-true
+True
 0
 3
 9
-true
-
+True

--- a/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@inexpr.txt.snap
+++ b/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@inexpr.txt.snap
@@ -1,15 +1,22 @@
 ---
-source: minijinja/tests/test_templates.rs
+source: crates/dbt-jinja/minijinja/tests/test_templates.rs
 description: "{{ 1 in seq }}\n{{ \"missing\" in seq }}\n{{ 1 not in seq }}\n{{ \"missing\" not in seq }}"
 info:
+  __minijinja_current_path: inexpr.txt
+  __minijinja_current_span:
+    end_col: 1
+    end_line: 1
+    end_offset: 0
+    start_col: 1
+    start_line: 1
+    start_offset: 0
   seq:
     - 1
     - 2
     - 3
-input_file: minijinja/tests/inputs/inexpr.txt
+input_file: crates/dbt-jinja/minijinja/tests/inputs/inexpr.txt
 ---
-true
-false
-false
-true
-
+True
+False
+False
+True

--- a/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@literals.txt.snap
+++ b/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@literals.txt.snap
@@ -1,11 +1,19 @@
 ---
 source: crates/dbt-jinja/minijinja/tests/test_templates.rs
 description: "{{ true }}\n{{ false }}\n{{ null }}\n{{ 1.0 }}\n{{ 2 }}\n{{ [1, 2, 3] }}\n{{ {\"foo\": \"bar\"} }}\n{{ -9223372036854775808 }}\n{{ -170141183460469231731687303715884105728 }}\n{{ 170141183460469231731687303715884105727 }}\n{{ 340282366920938463463374607431768211455 }}"
-info: {}
+info:
+  __minijinja_current_path: literals.txt
+  __minijinja_current_span:
+    end_col: 1
+    end_line: 1
+    end_offset: 0
+    start_col: 1
+    start_line: 1
+    start_offset: 0
 input_file: crates/dbt-jinja/minijinja/tests/inputs/literals.txt
 ---
-true
-false
+True
+False
 
 1.0
 2

--- a/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@loop_string.txt.snap
+++ b/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@loop_string.txt.snap
@@ -1,13 +1,21 @@
 ---
-source: minijinja/tests/test_templates.rs
+source: crates/dbt-jinja/minijinja/tests/test_templates.rs
 description: "{% for item in seq %}\n  {{ item }} ({{ loop.index }} of {{ loop.length }})\n    first={{ loop.first }}\n    last={{ loop.last }}\n    revindex={{ loop.revindex }}\n    revindex0={{ loop.revindex0 }}\n    cycle={{ loop.cycle(\"odd\", \"even\") }}\n    previtem={{ loop.previtem }}\n    nextitem={{ loop.nextitem }}\n{% endfor %}"
 info:
+  __minijinja_current_path: loop_string.txt
+  __minijinja_current_span:
+    end_col: 1
+    end_line: 1
+    end_offset: 0
+    start_col: 1
+    start_line: 1
+    start_offset: 0
   seq: abcd
-input_file: minijinja/tests/inputs/loop_string.txt
+input_file: crates/dbt-jinja/minijinja/tests/inputs/loop_string.txt
 ---
   a (1 of 4)
-    first=true
-    last=false
+    first=True
+    last=False
     revindex=4
     revindex0=3
     cycle=odd
@@ -15,8 +23,8 @@ input_file: minijinja/tests/inputs/loop_string.txt
     nextitem=b
 
   b (2 of 4)
-    first=false
-    last=false
+    first=False
+    last=False
     revindex=3
     revindex0=2
     cycle=even
@@ -24,8 +32,8 @@ input_file: minijinja/tests/inputs/loop_string.txt
     nextitem=c
 
   c (3 of 4)
-    first=false
-    last=false
+    first=False
+    last=False
     revindex=2
     revindex0=1
     cycle=odd
@@ -33,8 +41,8 @@ input_file: minijinja/tests/inputs/loop_string.txt
     nextitem=d
 
   d (4 of 4)
-    first=false
-    last=true
+    first=False
+    last=True
     revindex=1
     revindex0=0
     cycle=even

--- a/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@loop_var.txt.snap
+++ b/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@loop_var.txt.snap
@@ -1,18 +1,25 @@
 ---
-source: minijinja/tests/test_templates.rs
+source: crates/dbt-jinja/minijinja/tests/test_templates.rs
 description: "{% for item in seq %}\n  {{ item }} ({{ loop.index }} of {{ loop.length }})\n    first={{ loop.first }}\n    last={{ loop.last }}\n    revindex={{ loop.revindex }}\n    revindex0={{ loop.revindex0 }}\n    cycle={{ loop.cycle(\"odd\", \"even\") }}\n    previtem={{ loop.previtem }}\n    nextitem={{ loop.nextitem }}\n{% endfor %}"
 info:
+  __minijinja_current_path: loop_var.txt
+  __minijinja_current_span:
+    end_col: 1
+    end_line: 1
+    end_offset: 0
+    start_col: 1
+    start_line: 1
+    start_offset: 0
   seq:
     - a
     - b
     - c
     - d
-input_file: minijinja/tests/inputs/loop_var.txt
+input_file: crates/dbt-jinja/minijinja/tests/inputs/loop_var.txt
 ---
-
   a (1 of 4)
-    first=true
-    last=false
+    first=True
+    last=False
     revindex=4
     revindex0=3
     cycle=odd
@@ -20,8 +27,8 @@ input_file: minijinja/tests/inputs/loop_var.txt
     nextitem=b
 
   b (2 of 4)
-    first=false
-    last=false
+    first=False
+    last=False
     revindex=3
     revindex0=2
     cycle=even
@@ -29,8 +36,8 @@ input_file: minijinja/tests/inputs/loop_var.txt
     nextitem=c
 
   c (3 of 4)
-    first=false
-    last=false
+    first=False
+    last=False
     revindex=2
     revindex0=1
     cycle=odd
@@ -38,12 +45,10 @@ input_file: minijinja/tests/inputs/loop_var.txt
     nextitem=d
 
   d (4 of 4)
-    first=false
-    last=true
+    first=False
+    last=True
     revindex=1
     revindex0=0
     cycle=even
     previtem=c
     nextitem=
-
-

--- a/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@macro_basic.txt.snap
+++ b/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@macro_basic.txt.snap
@@ -1,7 +1,15 @@
 ---
 source: crates/dbt-jinja/minijinja/tests/test_templates.rs
 description: "{% macro add(a, b) %}{{ a }}|{{ b }}{% endmacro -%}\n{{ add(1, 2) }}\n{{ add(a=1, b=2) }}\n{{ add(b=2, a=1) }}\n{{ add(1, b=2) }}\n{{ add.name }}\n{{ add.arguments }}\n{{ add.caller }}\n{{ add }}"
-info: {}
+info:
+  __minijinja_current_path: macro_basic.txt
+  __minijinja_current_span:
+    end_col: 1
+    end_line: 1
+    end_offset: 0
+    start_col: 1
+    start_line: 1
+    start_offset: 0
 input_file: crates/dbt-jinja/minijinja/tests/inputs/macro_basic.txt
 ---
 1|2
@@ -10,5 +18,5 @@ input_file: crates/dbt-jinja/minijinja/tests/inputs/macro_basic.txt
 1|2
 add
 ('a', 'b')
-false
+False
 <macro add>

--- a/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@macro_caller.txt.snap
+++ b/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@macro_caller.txt.snap
@@ -1,11 +1,17 @@
 ---
-source: minijinja/tests/test_templates.rs
+source: crates/dbt-jinja/minijinja/tests/test_templates.rs
 description: "{% macro render_dialog(title, class='dialog') -%}\n    <div class=\"{{ class }}\">\n        <h2>{{ title }}</h2>\n        <div class=\"contents\">\n            {{ caller() }}\n        </div>\n    </div>\n{%- endmacro %}\n\n{% call render_dialog('Hello World') %}\n    This is a simple dialog rendered by using a macro and\n    a call block.\n{% endcall %}\n\ncaller: {{ render_dialog.caller }}"
-info: {}
-input_file: minijinja/tests/inputs/macro_caller.txt
+info:
+  __minijinja_current_path: macro_caller.txt
+  __minijinja_current_span:
+    end_col: 1
+    end_line: 1
+    end_offset: 0
+    start_col: 1
+    start_line: 1
+    start_offset: 0
+input_file: crates/dbt-jinja/minijinja/tests/inputs/macro_caller.txt
 ---
-
-
 <div class="dialog">
         <h2>Hello World</h2>
         <div class="contents">
@@ -16,5 +22,4 @@ input_file: minijinja/tests/inputs/macro_caller.txt
         </div>
     </div>
 
-caller: true
-
+caller: True

--- a/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@macro_caller_methods.txt.snap
+++ b/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@macro_caller_methods.txt.snap
@@ -2,13 +2,21 @@
 source: crates/dbt-jinja/minijinja/tests/test_templates.rs
 description: "{% macro info(a, b) %}\n  closure: {{ closure }}\n  name: {{ caller.name }}\n  args: {{ caller.arguments }}\n  caller: {{ caller.caller }}\n  a: {{ a }}\n  b: {{ b }}\n  result: {{ caller(a, b) }}\n{% endmacro %}\n\n{% set closure = \"other closure\" %}\n{% call(a, b) info(1, 2) %}{{ [a, b, closure] }}{% endcall %}"
 info:
+  __minijinja_current_path: macro_caller_methods.txt
+  __minijinja_current_span:
+    end_col: 1
+    end_line: 1
+    end_offset: 0
+    start_col: 1
+    start_line: 1
+    start_offset: 0
   closure: original closure
 input_file: crates/dbt-jinja/minijinja/tests/inputs/macro_caller_methods.txt
 ---
   closure: other closure
   name: caller
   args: ('a', 'b')
-  caller: false
+  caller: False
   a: 1
   b: 2
   result: [1, 2, 'other closure']

--- a/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@tests.txt.snap
+++ b/crates/dbt-jinja/minijinja/tests/snapshots/test_templates__vm@tests.txt.snap
@@ -1,62 +1,70 @@
 ---
-source: minijinja/tests/test_templates.rs
+source: crates/dbt-jinja/minijinja/tests/test_templates.rs
 description: "even: {{ two is even }}\nodd: {{ two is odd }}\nundefined: {{ two is undefined }}\ndefined: {{ two is defined }}\nundefined2: {{ ohwell is undefined }}\ndefined2: {{ ohwell is defined }}\nnone: {{ none is none }}\nnot-none: {{ 42 is not none }}\nnumber-int: {{ two is number }}\nnumber-float: {{ two_dot_two is number }}\ninteger-int: {{ 42 is integer }}\ninteger-float: {{ 42.0 is integer }}\nfloat-int: {{ 42 is float }}\nfloat-float: {{ 42.0 is float }}\nnot-seq: {{ two is sequence }}\nseq: {{ seq is sequence }}\nreverse-not-seq: {{ seq|reverse is sequence }}\niterable: {{ seq is iterable }}\niterable-reverse: {{ seq|reverse is iterable }}\nstring-iterable: {{ string is iterable }}\nnot-iterable: {{ two is iterable }}\nnot-map: {{ two is mapping }}\nmap: {{ map is mapping }}\nstring: {{ string is string }}\nnot-string: {{ mapping is string }}\nstarts-with-a: {{ string is startingwith('a') }}\nstarts-with-a-noparen: {{ string is startingwith 'a' }}\nends-with-ha: {{ string is endingwith('ha') }}\nends-with-ha-noparen: {{ string is endingwith 'ha' }}\nnot-safe: {{ \"foo\" is safe }}\nsafe: {{ \"foo\"|escape is safe }}\nis-true: {{ true is true }} | {{ 42 is true }}\nis-false: {{ false is false }} | {{ 0 is false }}\nis-filter: {{ 'escape' is filter }} | {{ 'unknown-filter' is filter }}\nis-test: {{ 'safe' is test }} | {{ 'unknown-test' is test }}\nis-boolean: {{ true is boolean }} | {{ 42 is boolean }}\nis-divisibleby: {{ 42 is divisibleby(2) }} | {{ 41 is divisibleby(2) }}\nis-divisibleby-noparen: {{ 42 is divisibleby(2) }} | {{ 41 is divisibleby 2 }}\nis-lower: {{ \"foo\" is lower }} | {{ \"FOO\" is lower }}\nis-upper: {{ \"foo\" is upper }} | {{ \"FOO\" is upper }}\nseq-same-as: {{ [1, 2, 3] is sameas([1, 2, 3]) }}\nseq-same-as-noparen: {{ [1, 2, 3] is sameas [1, 2, 3] }}\nconst-same-as: {{ true is sameas(true) }}\nconst-same-as-noparen: {{ true is sameas true }}\nint-same-as: {{ 1 is sameas(1.0) }}\nint-same-as-noparen: {{ 1 is sameas 1.0 }}\nneg-int-same-as-noparen: {{ -1 is sameas -1 }}"
 info:
-  two: 2
-  two_dot_two: 2.2
+  __minijinja_current_path: tests.txt
+  __minijinja_current_span:
+    end_col: 1
+    end_line: 1
+    end_offset: 0
+    start_col: 1
+    start_line: 1
+    start_offset: 0
+  map:
+    foo: bar
   seq:
     - 1
     - 2
     - 3
-  map:
-    foo: bar
   string: aha
-input_file: minijinja/tests/inputs/tests.txt
+  two: 2
+  two_dot_two: 2.2
+input_file: crates/dbt-jinja/minijinja/tests/inputs/tests.txt
 ---
-even: true
-odd: false
-undefined: false
-defined: true
-undefined2: true
-defined2: false
-none: true
-not-none: true
-number-int: true
-number-float: true
-integer-int: true
-integer-float: false
-float-int: false
-float-float: true
-not-seq: false
-seq: true
-reverse-not-seq: false
-iterable: true
-iterable-reverse: true
-string-iterable: true
-not-iterable: false
-not-map: false
-map: true
-string: true
-not-string: false
-starts-with-a: true
-starts-with-a-noparen: true
-ends-with-ha: true
-ends-with-ha-noparen: true
-not-safe: false
-safe: true
-is-true: true | false
-is-false: true | false
-is-filter: true | false
-is-test: true | false
-is-boolean: true | false
-is-divisibleby: true | false
-is-divisibleby-noparen: true | false
-is-lower: true | false
-is-upper: false | true
-seq-same-as: false
-seq-same-as-noparen: false
-const-same-as: true
-const-same-as-noparen: true
-int-same-as: false
-int-same-as-noparen: false
-neg-int-same-as-noparen: true
+even: True
+odd: False
+undefined: False
+defined: True
+undefined2: True
+defined2: False
+none: True
+not-none: True
+number-int: True
+number-float: True
+integer-int: True
+integer-float: False
+float-int: False
+float-float: True
+not-seq: False
+seq: True
+reverse-not-seq: False
+iterable: True
+iterable-reverse: True
+string-iterable: True
+not-iterable: False
+not-map: False
+map: True
+string: True
+not-string: False
+starts-with-a: True
+starts-with-a-noparen: True
+ends-with-ha: True
+ends-with-ha-noparen: True
+not-safe: False
+safe: True
+is-true: True | False
+is-false: True | False
+is-filter: True | False
+is-test: True | False
+is-boolean: True | False
+is-divisibleby: True | False
+is-divisibleby-noparen: True | False
+is-lower: True | False
+is-upper: False | True
+seq-same-as: False
+seq-same-as-noparen: False
+const-same-as: True
+const-same-as-noparen: True
+int-same-as: False
+int-same-as-noparen: False
+neg-int-same-as-noparen: True

--- a/crates/dbt-jinja/minijinja/tests/test_state.rs
+++ b/crates/dbt-jinja/minijinja/tests/test_state.rs
@@ -9,5 +9,5 @@ fn test_state_lookup_global() {
     });
     env.add_global("the_global", true);
     let rv = env.render_str("[{{ lookup_global() }}]", (), &[]).unwrap();
-    assert_eq!(rv, "[true]");
+    assert_eq!(rv, "[True]");
 }

--- a/crates/dbt-jinja/minijinja/tests/test_templates.rs
+++ b/crates/dbt-jinja/minijinja/tests/test_templates.rs
@@ -709,5 +709,5 @@ fn test_test_caching() {
         .unwrap()
         .render((), &[])
         .unwrap();
-    assert_eq!(rv, "false");
+    assert_eq!(rv, "False");
 }

--- a/crates/dbt-jinja/minijinja/tests/test_undefined.rs
+++ b/crates/dbt-jinja/minijinja/tests/test_undefined.rs
@@ -26,16 +26,16 @@ fn test_lenient_undefined() {
         render!(in env, "<{% for x in undefined %}...{% endfor %}>"),
         "<>"
     );
-    assert_eq!(render!(in env, "{{ 'foo' is in(undefined) }}"), "false");
+    assert_eq!(render!(in env, "{{ 'foo' is in(undefined) }}"), "False");
     assert_eq!(render!(in env, "<{{ undefined }}>"), "<>");
-    assert_eq!(render!(in env, "{{ undefined is undefined }}"), "true");
+    assert_eq!(render!(in env, "{{ undefined is undefined }}"), "True");
     assert_eq!(
         render!(in env, "{{ x.foo is undefined }}", x => HashMap::<String, String>::new()),
-        "true"
+        "True"
     );
     assert_eq!(render!(in env, "{{ undefined|list }}"), "[]");
     assert_eq!(render!(in env, "<{{ undefined|test }}>"), "<>");
-    assert_eq!(render!(in env, "{{ 42 in undefined }}"), "false");
+    assert_eq!(render!(in env, "{{ 42 in undefined }}"), "False");
 }
 
 #[test]
@@ -73,10 +73,10 @@ fn test_strict_undefined() {
             .kind(),
         ErrorKind::UndefinedError
     );
-    assert_eq!(render!(in env, "{{ undefined is undefined }}"), "true");
+    assert_eq!(render!(in env, "{{ undefined is undefined }}"), "True");
     assert_eq!(
         render!(in env, "{{ x.foo is undefined }}", x => HashMap::<String, String>::new()),
-        "true"
+        "True"
     );
     assert_eq!(
         env.render_str(
@@ -120,12 +120,12 @@ fn test_chainable_undefined() {
     );
     assert_eq!(
         render!(in env, "{{ x.foo is undefined }}", x => HashMap::<String, String>::new()),
-        "true"
+        "True"
     );
-    assert_eq!(render!(in env, "{{ 'foo' is in(undefined) }}"), "false");
+    assert_eq!(render!(in env, "{{ 'foo' is in(undefined) }}"), "False");
     assert_eq!(render!(in env, "<{{ undefined }}>"), "<>");
-    assert_eq!(render!(in env, "{{ undefined is undefined }}"), "true");
+    assert_eq!(render!(in env, "{{ undefined is undefined }}"), "True");
     assert_eq!(render!(in env, "{{ undefined|list }}"), "[]");
     assert_eq!(render!(in env, "<{{ undefined|test }}>"), "<>");
-    assert_eq!(render!(in env, "{{ 42 in undefined }}"), "false");
+    assert_eq!(render!(in env, "{{ 42 in undefined }}"), "False");
 }

--- a/crates/dbt-jinja/minijinja/tests/test_value.rs
+++ b/crates/dbt-jinja/minijinja/tests/test_value.rs
@@ -949,7 +949,7 @@ fn test_plain_object() {
 
     let x = Value::from_object(X);
     assert!(x.try_iter().is_err());
-    assert_snapshot!(render!("{{ x }}|{{ x.missing_attr is undefined }}", x), @"X|true");
+    assert_snapshot!(render!("{{ x }}|{{ x.missing_attr is undefined }}", x), @"X|True");
 }
 
 #[test]

--- a/crates/dbt-jinja/minijinja/tests/test_vm.rs
+++ b/crates/dbt-jinja/minijinja/tests/test_vm.rs
@@ -154,7 +154,7 @@ fn test_op_eq() {
     c.add(Instruction::Emit(Span::default()));
 
     let output = simple_eval(&c.finish().0, ()).unwrap();
-    assert_eq!(output, "true");
+    assert_eq!(output, "True");
 
     let mut c = CodeGenerator::new("hello.html", "", CodeGenerationProfile::Render);
     c.add(Instruction::LoadConst(Value::from(1)));
@@ -163,7 +163,7 @@ fn test_op_eq() {
     c.add(Instruction::Emit(Span::default()));
 
     let output = simple_eval(&c.finish().0, ()).unwrap();
-    assert_eq!(output, "false");
+    assert_eq!(output, "False");
 }
 
 #[test]
@@ -175,7 +175,7 @@ fn test_op_ne() {
     c.add(Instruction::Emit(Span::default()));
 
     let output = simple_eval(&c.finish().0, ()).unwrap();
-    assert_eq!(output, "true");
+    assert_eq!(output, "True");
 
     let mut c = CodeGenerator::new("<unknown>", "", CodeGenerationProfile::Render);
     c.add(Instruction::LoadConst(Value::from("foo")));
@@ -184,7 +184,7 @@ fn test_op_ne() {
     c.add(Instruction::Emit(Span::default()));
 
     let output = simple_eval(&c.finish().0, ()).unwrap();
-    assert_eq!(output, "false");
+    assert_eq!(output, "False");
 }
 
 #[test]
@@ -196,7 +196,7 @@ fn test_op_lt() {
     c.add(Instruction::Emit(Span::default()));
 
     let output = simple_eval(&c.finish().0, ()).unwrap();
-    assert_eq!(output, "true");
+    assert_eq!(output, "True");
 
     let mut c = CodeGenerator::new("<unknown>", "", CodeGenerationProfile::Render);
     c.add(Instruction::LoadConst(Value::from(2)));
@@ -205,7 +205,7 @@ fn test_op_lt() {
     c.add(Instruction::Emit(Span::default()));
 
     let output = simple_eval(&c.finish().0, ()).unwrap();
-    assert_eq!(output, "false");
+    assert_eq!(output, "False");
 }
 
 #[test]
@@ -217,7 +217,7 @@ fn test_op_gt() {
     c.add(Instruction::Emit(Span::default()));
 
     let output = simple_eval(&c.finish().0, ()).unwrap();
-    assert_eq!(output, "false");
+    assert_eq!(output, "False");
 
     let mut c = CodeGenerator::new("<unknown>", "", CodeGenerationProfile::Render);
     c.add(Instruction::LoadConst(Value::from(2)));
@@ -226,7 +226,7 @@ fn test_op_gt() {
     c.add(Instruction::Emit(Span::default()));
 
     let output = simple_eval(&c.finish().0, ()).unwrap();
-    assert_eq!(output, "true");
+    assert_eq!(output, "True");
 }
 
 #[test]
@@ -238,7 +238,7 @@ fn test_op_lte() {
     c.add(Instruction::Emit(Span::default()));
 
     let output = simple_eval(&c.finish().0, ()).unwrap();
-    assert_eq!(output, "true");
+    assert_eq!(output, "True");
 
     let mut c = CodeGenerator::new("<unknown>", "", CodeGenerationProfile::Render);
     c.add(Instruction::LoadConst(Value::from(2)));
@@ -247,7 +247,7 @@ fn test_op_lte() {
     c.add(Instruction::Emit(Span::default()));
 
     let output = simple_eval(&c.finish().0, ()).unwrap();
-    assert_eq!(output, "false");
+    assert_eq!(output, "False");
 }
 
 #[test]
@@ -259,7 +259,7 @@ fn test_op_gte() {
     c.add(Instruction::Emit(Span::default()));
 
     let output = simple_eval(&c.finish().0, ()).unwrap();
-    assert_eq!(output, "false");
+    assert_eq!(output, "False");
 
     let mut c = CodeGenerator::new("<unknown>", "", CodeGenerationProfile::Render);
     c.add(Instruction::LoadConst(Value::from(1)));
@@ -268,7 +268,7 @@ fn test_op_gte() {
     c.add(Instruction::Emit(Span::default()));
 
     let output = simple_eval(&c.finish().0, ()).unwrap();
-    assert_eq!(output, "true");
+    assert_eq!(output, "True");
 }
 
 #[test]
@@ -279,7 +279,7 @@ fn test_op_not() {
     c.add(Instruction::Emit(Span::default()));
 
     let output = simple_eval(&c.finish().0, ()).unwrap();
-    assert_eq!(output, "true");
+    assert_eq!(output, "True");
 
     let mut c = CodeGenerator::new("<unknown>", "", CodeGenerationProfile::Render);
     c.add(Instruction::LoadConst(Value::from(true)));
@@ -287,7 +287,7 @@ fn test_op_not() {
     c.add(Instruction::Emit(Span::default()));
 
     let output = simple_eval(&c.finish().0, ()).unwrap();
-    assert_eq!(output, "false");
+    assert_eq!(output, "False");
 }
 
 #[test]

--- a/crates/dbt-parser/src/resolver.rs
+++ b/crates/dbt-parser/src/resolver.rs
@@ -243,7 +243,6 @@ pub async fn resolve(
     // Check access
     check_access(arg, &nodes, &all_runtime_configs);
 
-
     Ok((
         ResolverState {
             root_project_name: root_project_name.to_string(),


### PR DESCRIPTION
Makes boolean rendering consistent with jinja2 / dbt-core.

Fixes part of #581 ("Boolean casing differences: Fusion mixes false (lowercase) and True (Title Case) inconsistently").