### PR TITLE
Make `modules.re` methods accept an already compiled pattern

### DIFF
--- a/.changes/unreleased/Fixes-20250824-234019.yaml
+++ b/.changes/unreleased/Fixes-20250824-234019.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Make modules.re methods accept an already compiled pattern
+time: 2025-08-24T23:40:19.408475+02:00

--- a/crates/dbt-jinja/minijinja-contrib/Cargo.toml
+++ b/crates/dbt-jinja/minijinja-contrib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minijinja-contrib"
 version = "2.5.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "Extra utilities for MiniJinja"
@@ -9,7 +9,7 @@ homepage = "https://github.com/mitsuhiko/minijinja"
 repository = "https://github.com/mitsuhiko/minijinja"
 keywords = ["jinja", "jinja2", "templates"]
 readme = "README.md"
-rust-version = "1.70"
+rust-version = "1.88.0"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "doc-header.html"]

--- a/crates/dbt-jinja/minijinja-contrib/src/filters/datetime.rs
+++ b/crates/dbt-jinja/minijinja-contrib/src/filters/datetime.rs
@@ -2,10 +2,10 @@ use std::convert::TryFrom;
 
 use minijinja::value::{Kwargs, Value, ValueKind};
 use minijinja::{Error, ErrorKind, State};
-use serde::de::value::SeqDeserializer;
 use serde::Deserialize;
+use serde::de::value::SeqDeserializer;
 use time::format_description::well_known::iso8601::Iso8601;
-use time::{format_description, Date, OffsetDateTime, PrimitiveDateTime};
+use time::{Date, OffsetDateTime, PrimitiveDateTime, format_description};
 
 fn handle_serde_error(err: serde::de::value::Error) -> Error {
     Error::new(ErrorKind::InvalidOperation, "not a valid date or timestamp").with_source(err)
@@ -39,7 +39,7 @@ fn value_to_datetime(
                             ErrorKind::InvalidOperation,
                             "not a valid date or timestamp",
                         )
-                        .with_source(original_err))
+                        .with_source(original_err));
                     }
                 },
             },

--- a/crates/dbt-jinja/minijinja-contrib/src/filters/mod.rs
+++ b/crates/dbt-jinja/minijinja-contrib/src/filters/mod.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 
-use minijinja::value::{Kwargs, Value, ValueKind};
 use minijinja::State;
+use minijinja::value::{Kwargs, Value, ValueKind};
 use minijinja::{Error, ErrorKind};
 
 #[cfg(feature = "datetime")]
@@ -262,7 +262,7 @@ pub fn wordcount(value: &Value) -> Result<Value, Error> {
 #[cfg(feature = "wordwrap")]
 #[cfg_attr(docsrs, doc(any(cfg(feature = "wordwrap"), cfg = "unicode_wordwrap")))]
 pub fn wordwrap(value: &Value, kwargs: Kwargs) -> Result<Value, Error> {
-    use textwrap::{wrap, Options as WrapOptions, WordSplitter};
+    use textwrap::{Options as WrapOptions, WordSplitter, wrap};
     let s = value.as_str().unwrap_or_default();
 
     let width = kwargs.get::<Option<usize>>("width")?.unwrap_or(79);

--- a/crates/dbt-jinja/minijinja-contrib/src/globals.rs
+++ b/crates/dbt-jinja/minijinja-contrib/src/globals.rs
@@ -1,11 +1,11 @@
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use minijinja::listener::RenderingEventListener;
 #[allow(unused)]
 use minijinja::value::Value;
-use minijinja::value::{from_args, Object, ObjectRepr};
+use minijinja::value::{Object, ObjectRepr, from_args};
 use minijinja::{Error, ErrorKind, State};
 
 /// Returns the current time in UTC as unix timestamp.
@@ -137,8 +137,8 @@ pub fn joiner(sep: Option<Value>) -> Value {
 /// Returns the rng for the state
 #[cfg(feature = "rand")]
 pub(crate) fn get_rng(state: &State) -> rand::rngs::SmallRng {
-    use rand::rngs::SmallRng;
     use rand::SeedableRng;
+    use rand::rngs::SmallRng;
 
     if let Some(seed) = state
         .lookup("RAND_SEED")
@@ -189,8 +189,8 @@ pub fn lipsum(
     n: Option<usize>,
     kwargs: minijinja::value::Kwargs,
 ) -> Result<Value, Error> {
-    use rand::seq::SliceRandom;
     use rand::Rng;
+    use rand::seq::SliceRandom;
 
     #[rustfmt::skip]
     const LIPSUM_WORDS: &[&str] = &[

--- a/crates/dbt-jinja/minijinja-contrib/src/modules/py_datetime/date.rs
+++ b/crates/dbt-jinja/minijinja-contrib/src/modules/py_datetime/date.rs
@@ -1,6 +1,6 @@
 use chrono::{Datelike, Local, NaiveDate, NaiveDateTime, TimeZone};
 use minijinja::arg_utils::ArgParser;
-use minijinja::{value::Object, Error, ErrorKind, Value};
+use minijinja::{Error, ErrorKind, Value, value::Object};
 use std::fmt;
 use std::sync::Arc;
 
@@ -336,9 +336,9 @@ impl Object for PyDate {
 mod tests {
     use super::*;
     use crate::modules::py_datetime::timedelta::PyTimeDelta;
+    use minijinja::Environment;
     use minijinja::args;
     use minijinja::context;
-    use minijinja::Environment;
 
     #[test]
     fn test_date_strftime() {
@@ -361,9 +361,11 @@ mod tests {
 
         // Test error case - missing format argument
         let error = date_arc.strftime(&[]).unwrap_err();
-        assert!(error
-            .to_string()
-            .contains("strftime requires one string argument"));
+        assert!(
+            error
+                .to_string()
+                .contains("strftime requires one string argument")
+        );
     }
 
     #[test]
@@ -546,9 +548,11 @@ mod tests {
         // Test invalid date
         let result = date_arc.replace(args!(month => 13));
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid date: year=2023, month=13, day=15"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid date: year=2023, month=13, day=15")
+        );
     }
 }

--- a/crates/dbt-jinja/minijinja-contrib/src/modules/py_datetime/datetime.rs
+++ b/crates/dbt-jinja/minijinja-contrib/src/modules/py_datetime/datetime.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Timelike, Utc};
 use chrono_tz::Tz;
-use minijinja::{arg_utils::ArgParser, value::Object, Error, ErrorKind, Value};
+use minijinja::{Error, ErrorKind, Value, arg_utils::ArgParser, value::Object};
 
 use crate::modules::py_datetime::date::PyDate; // your date
 use crate::modules::py_datetime::time::PyTime;

--- a/crates/dbt-jinja/minijinja-contrib/src/modules/py_datetime/time.rs
+++ b/crates/dbt-jinja/minijinja-contrib/src/modules/py_datetime/time.rs
@@ -1,5 +1,5 @@
 use chrono::{Local, NaiveDate, NaiveTime, Timelike};
-use minijinja::{arg_utils::ArgParser, value::Object, Error, ErrorKind, Value};
+use minijinja::{Error, ErrorKind, Value, arg_utils::ArgParser, value::Object};
 use std::fmt;
 use std::sync::Arc;
 
@@ -92,7 +92,7 @@ impl PyTimeClass {
                 return Err(Error::new(
                     ErrorKind::InvalidArgument,
                     format!("Invalid iso time format: {iso_str}: {e}"),
-                ))
+                ));
             }
         };
 
@@ -318,8 +318,8 @@ impl Object for PyTime {
 mod tests {
     use super::*;
     use crate::modules::py_datetime::timedelta::PyTimeDelta;
-    use minijinja::context;
     use minijinja::Environment;
+    use minijinja::context;
 
     #[test]
     fn test_time_strftime() {
@@ -342,9 +342,11 @@ mod tests {
 
         // Test error case - missing format argument
         let error = time_arc.strftime(&[]).unwrap_err();
-        assert!(error
-            .to_string()
-            .contains("strftime requires one string argument"));
+        assert!(
+            error
+                .to_string()
+                .contains("strftime requires one string argument")
+        );
     }
 
     #[test]

--- a/crates/dbt-jinja/minijinja-contrib/src/modules/py_datetime/timedelta.rs
+++ b/crates/dbt-jinja/minijinja-contrib/src/modules/py_datetime/timedelta.rs
@@ -1,5 +1,5 @@
 use chrono::Duration;
-use minijinja::{arg_utils::ArgParser, value::Object, Error, ErrorKind, Value};
+use minijinja::{Error, ErrorKind, Value, arg_utils::ArgParser, value::Object};
 use std::fmt;
 use std::sync::Arc;
 
@@ -263,9 +263,9 @@ impl Object for PyTimeDelta {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use minijinja::args;
     use minijinja::Environment;
     use minijinja::Value;
+    use minijinja::args;
 
     #[test]
     fn test_timedelta_creation() {

--- a/crates/dbt-jinja/minijinja-contrib/src/modules/py_datetime/tzinfo.rs
+++ b/crates/dbt-jinja/minijinja-contrib/src/modules/py_datetime/tzinfo.rs
@@ -1,4 +1,4 @@
-use minijinja::{value::Object, Error, ErrorKind, Value};
+use minijinja::{Error, ErrorKind, Value, value::Object};
 use std::fmt;
 use std::rc::Rc;
 use std::sync::Arc;

--- a/crates/dbt-jinja/minijinja-contrib/src/modules/re.rs
+++ b/crates/dbt-jinja/minijinja-contrib/src/modules/re.rs
@@ -6,7 +6,7 @@
 //! pattern-oriented usage consistent with MiniJinja's function/value approach.
 
 use fancy_regex::{Captures, Expander, Regex}; // like python regex, fancy_regex supports lookadheds/lookbehinds
-use minijinja::{value::Object, Error, ErrorKind, Value};
+use minijinja::{Error, ErrorKind, Value, value::Object};
 use std::{collections::BTreeMap, iter, sync::Arc};
 
 /// Create a namespace with `re`-like functions for pattern matching.

--- a/crates/dbt-jinja/minijinja-contrib/src/pycompat.rs
+++ b/crates/dbt-jinja/minijinja-contrib/src/pycompat.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use minijinja::tuple;
 use minijinja::value::mutable_vec::MutableVec;
-use minijinja::value::{from_args, ValueKind};
+use minijinja::value::{ValueKind, from_args};
 use minijinja::{Error, ErrorKind, State, Value};
 use regex::Regex;
 

--- a/crates/dbt-jinja/minijinja-contrib/tests/filters.rs
+++ b/crates/dbt-jinja/minijinja-contrib/tests/filters.rs
@@ -1,4 +1,4 @@
-use minijinja::{context, Environment};
+use minijinja::{Environment, context};
 use minijinja_contrib::filters::pluralize;
 use similar_asserts::assert_eq;
 

--- a/crates/dbt-jinja/minijinja-contrib/tests/globals.rs
+++ b/crates/dbt-jinja/minijinja-contrib/tests/globals.rs
@@ -1,5 +1,5 @@
 use insta::assert_snapshot;
-use minijinja::{render, Environment};
+use minijinja::{Environment, render};
 use minijinja_contrib::globals::{cycler, joiner};
 
 #[test]

--- a/crates/dbt-jinja/minijinja-contrib/tests/validation.rs
+++ b/crates/dbt-jinja/minijinja-contrib/tests/validation.rs
@@ -10,27 +10,35 @@ fn test_validation() {
     let mut env = Environment::new();
     env.add_global("validation", create_validation_namespace());
 
-    assert!(eval_expr(
-        &env,
-        "validation.any['compound', 'interleaved']('compound')"
-    )
-    .unwrap()
-    .is_true());
-    assert!(eval_expr(
-        &env,
-        "validation.any['compound', 'interleaved']('interleaved')"
-    )
-    .unwrap()
-    .is_true());
-    assert!(eval_expr(
-        &env,
-        "validation.any['compound', 'interleaved']('something_else')"
-    )
-    .is_err());
-
-    assert!(eval_expr(&env, "validation.any['compound']('compound')")
+    assert!(
+        eval_expr(
+            &env,
+            "validation.any['compound', 'interleaved']('compound')"
+        )
         .unwrap()
-        .is_true());
+        .is_true()
+    );
+    assert!(
+        eval_expr(
+            &env,
+            "validation.any['compound', 'interleaved']('interleaved')"
+        )
+        .unwrap()
+        .is_true()
+    );
+    assert!(
+        eval_expr(
+            &env,
+            "validation.any['compound', 'interleaved']('something_else')"
+        )
+        .is_err()
+    );
+
+    assert!(
+        eval_expr(&env, "validation.any['compound']('compound')")
+            .unwrap()
+            .is_true()
+    );
     assert!(eval_expr(&env, "validation.any['compound']('something_else')").is_err());
     // compound here is a type, we should always return true when type is used
     assert!(
@@ -38,10 +46,14 @@ fn test_validation() {
             .unwrap()
             .is_true()
     );
-    assert!(eval_expr(&env, "validation.any[anytype](1)")
-        .unwrap()
-        .is_true());
-    assert!(eval_expr(&env, "validation.any['test', anytype](1)")
-        .unwrap()
-        .is_true());
+    assert!(
+        eval_expr(&env, "validation.any[anytype](1)")
+            .unwrap()
+            .is_true()
+    );
+    assert!(
+        eval_expr(&env, "validation.any['test', anytype](1)")
+            .unwrap()
+            .is_true()
+    );
 }


### PR DESCRIPTION
Fixes part of #581 ("Compilation failures: The user's example still produces empty files in Fusion").

Methods in `modules.re` (such as `search` and `match`) can take both a string for the initial pattern argument as well an already compiled expression.

Before this change only the string variant was correctly supported:
```jinja2
{%- set pattern = '.*' -%}
{%- set result = re.search(pattern, 'xyz') -%}
```

This change makes compiled patterns work as well, restoring compatibility with [pythons re](https://docs.python.org/3/library/re.html)  / dbt-core / jinja2:
```jinja2
{%- set pattern = re.compile('.*') -%}
{%- set result = re.search(pattern, 'xyz') -%}
```

The rust edition in the `minijinja-contrib` crate was bumped to `2024` to allow the [let chain](https://github.com/rust-lang/rust/pull/132833) used here. Bumping the edition means that `cargo fmt` formats differently - the (otherwise unrelated) formatting changes are done in the second commit in this PR, while the first commit contains the actual change.