### PR TITLE
Implement rendering `modules.re.Match` objects

### DIFF
--- a/.changes/unreleased/Fixes-20250825-003102.yaml
+++ b/.changes/unreleased/Fixes-20250825-003102.yaml
@@ -1,0 +1,3 @@
+kind: Fixes
+body: Implement rendering modules.re.Match objects
+time: 2025-08-25T00:31:02.282154+02:00

--- a/crates/dbt-jinja/minijinja-contrib/src/modules/re.rs
+++ b/crates/dbt-jinja/minijinja-contrib/src/modules/re.rs
@@ -387,6 +387,7 @@ impl Object for Capture {
             if let Some((start, end)) = self.span {
                 write!(f, "span = ({start}, {end}), ")?;
             }
+            // TODO: escape quotes in g
             write!(f, "match = '{g}'")?;
         }
         write!(f, ">")

--- a/crates/dbt-jinja/minijinja-contrib/src/modules/re.rs
+++ b/crates/dbt-jinja/minijinja-contrib/src/modules/re.rs
@@ -7,7 +7,7 @@
 
 use fancy_regex::{Captures, Expander, Regex}; // like python regex, fancy_regex supports lookadheds/lookbehinds
 use minijinja::{value::Object, Error, ErrorKind, Value};
-use std::{collections::BTreeMap, iter, sync::Arc};
+use std::{collections::BTreeMap, fmt, iter, sync::Arc};
 
 /// Create a namespace with `re`-like functions for pattern matching.
 pub fn create_re_namespace() -> BTreeMap<String, Value> {
@@ -121,10 +121,14 @@ fn re_match(args: &[Value]) -> Result<Value, Error> {
             .iter()
             .map(|m| Value::from(m.map(|m| m.as_str()).unwrap_or_default()))
             .collect();
-        let capture = Capture::new(groups);
+        let span: Option<(usize, usize)> = captures
+            .iter()
+            .next()
+            .and_then(|m| m.map(|m| (m.start(), m.end())));
+        let capture = Capture::new(groups, span);
         Ok(Value::from_object(capture))
     } else {
-        Ok(Value::from_object(Capture::default()))
+        Ok(Value::NONE)
     }
 }
 
@@ -145,10 +149,14 @@ fn re_search(args: &[Value]) -> Result<Value, Error> {
             .iter()
             .map(|m| Value::from(m.map(|m| m.as_str()).unwrap_or_default()))
             .collect();
-        let capture = Capture::new(groups);
+        let span = captures
+            .iter()
+            .next()
+            .and_then(|m| m.map(|m| (m.start(), m.end())));
+        let capture = Capture::new(groups, span);
         Ok(Value::from_object(capture))
     } else {
-        Ok(Value::from_object(Capture::default()))
+        Ok(Value::NONE)
     }
 }
 
@@ -196,7 +204,11 @@ fn re_findall(args: &[Value]) -> Result<Value, Error> {
                         .skip(1)
                         .map(|m| Value::from(m.map(|m| m.as_str()).unwrap_or_default()))
                         .collect();
-                    let capture = Capture::new(groups);
+                    let span = captures
+                        .iter()
+                        .nth(1)
+                        .and_then(|m| m.map(|m| (m.start(), m.end())));
+                    let capture = Capture::new(groups, span);
                     Value::from_object(capture)
                 }
             })
@@ -322,14 +334,15 @@ fn match_obj_to_list(re: &Regex, text: &str, start: usize, end: usize) -> Value 
         Value::from(&text[start..end])
     }
 }
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Capture {
     groups: Vec<Value>,
+    span: Option<(usize, usize)>,
 }
 
 impl Capture {
-    pub fn new(groups: Vec<Value>) -> Self {
-        Self { groups }
+    pub fn new(groups: Vec<Value>, span: Option<(usize, usize)>) -> Self {
+        Self { groups, span }
     }
 }
 
@@ -363,6 +376,20 @@ impl Object for Capture {
 
     fn is_true(self: &Arc<Self>) -> bool {
         !self.groups.is_empty()
+    }
+
+    fn render(self: &Arc<Self>, f: &mut fmt::Formatter<'_>) -> fmt::Result
+    where
+        Self: Sized + 'static,
+    {
+        write!(f, "<re.Match object; ")?;
+        if let Some(g) = self.groups.first() {
+            if let Some((start, end)) = self.span {
+                write!(f, "span = ({start}, {end}), ")?;
+            }
+            write!(f, "match = '{g}'")?;
+        }
+        write!(f, ">")
     }
 }
 
@@ -398,6 +425,10 @@ mod tests {
         ])
         .unwrap();
         assert!(result.is_true());
+        assert_eq!(
+            result.to_string(),
+            "<re.Match object; span = (0, 3), match = 'xyz'>"
+        );
 
         let result = re_match(&[
             Value::from("\\d{10}".to_string()),
@@ -405,6 +436,10 @@ mod tests {
         ])
         .unwrap();
         assert!(result.is_true());
+        assert_eq!(
+            result.to_string(),
+            "<re.Match object; span = (0, 10), match = '1234567890'>"
+        );
 
         let result = re_match(&[
             Value::from("\\d{10}".to_string()),
@@ -412,5 +447,28 @@ mod tests {
         ])
         .unwrap();
         assert!(!result.is_true());
+        assert_eq!(result.to_string(), "none");
+    }
+
+    #[test]
+    fn test_re_search() {
+        let result = re_search(&[
+            Value::from("world".to_string()),
+            Value::from("hello, world".to_string()),
+        ])
+        .unwrap();
+        assert!(result.is_true());
+        assert_eq!(
+            result.to_string(),
+            "<re.Match object; span = (7, 12), match = 'world'>"
+        );
+
+        let result = re_search(&[
+            Value::from("hello".to_string()),
+            Value::from("world".to_string()),
+        ])
+        .unwrap();
+        assert!(!result.is_true());
+        assert_eq!(result.to_string(), "none");
     }
 }

--- a/crates/dbt-jinja/minijinja/src/value/mod.rs
+++ b/crates/dbt-jinja/minijinja/src/value/mod.rs
@@ -747,6 +747,12 @@ impl Value {
     /// and this is the only way to construct it.
     pub const UNDEFINED: Value = Value(ValueRepr::Undefined);
 
+    /// The none value.
+    ///
+    /// This constant exists because the none type does not exist in Rust
+    /// and this is the only way to construct it.
+    pub const NONE: Value = Value(ValueRepr::None);
+
     /// Creates a value from something that can be serialized.
     ///
     /// This is the method that MiniJinja will generally use whenever a serializable


### PR DESCRIPTION
Fixes part of #581 ("Information loss: Fusion renders Match objects as empty {} instead of showing the actual match details").

Before this change:

```jinja2
{{ modules.re.match('.*', 'xyz') }}
{{ modules.re.match('test', 'xyz') }}
```

rendered as:

```
{}
{}
```

After this change the same template renders as:

```
<re.Match object; span=(0, 3), match='xyz'>
none
```
