### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,6 @@ All notable changes to this project will be documented in this file.
 
 ## 2.0.0-preview.21 - September 18, 2025
 
-### Features
-
-- [dbt-fusion] Allow for --write-catalog for dbt parse
-
 ### Fixes
 
 - [dbt-extension] improved logic for identifying a dbt project


### PR DESCRIPTION
Definitely a nit, but we don't want to advertise write-catalog as a feature.

Long term it'll only be for users who need to access the legacy artifact, which we would also want to discourage. Short term, it'll be run under the hood and there are no recommend user facing impacts. We primarily introduced this so we could replace docs-generate. Broadly, the goal is to hydrate everything needed for your metadata automatically with build and run with the new platform rather than rely on extra commands for users to see their metadata hydrated in the platform.

https://dbt-labs.slack.com/archives/C094BCVA264/p1758564681222229