### PR TITLE
feat(dbt-sa-cli): Add dotenvy to read .env files

### DIFF
--- a/.changes/unreleased/Features-20250923-091442.yaml
+++ b/.changes/unreleased/Features-20250923-091442.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Parse .env files when running the CLI
+time: 2025-09-23T09:14:42.204484979+02:00
+custom:
+    author: glennib
+    issue: ""
+    project: dbt-fusion

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -398,6 +398,7 @@ chrono-tz = { version = "0.10" }
 clap = { version = "4.4.4", features = ["derive"] }
 counter = "0.6.0"
 dashmap = "6.1.0"
+dotenvy = "0.15.7"
 fancy-regex = "0.14.0"
 hex = { version = "0.4.3" }
 humantime = "2.1.0"

--- a/crates/dbt-sa-cli/Cargo.toml
+++ b/crates/dbt-sa-cli/Cargo.toml
@@ -25,6 +25,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 clap = { workspace = true, features = ["derive"] }
+dotenvy = { workspace = true }
 log = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }

--- a/crates/dbt-sa-cli/src/main.rs
+++ b/crates/dbt-sa-cli/src/main.rs
@@ -24,6 +24,9 @@ fn main() -> ExitCode {
     // TODO(felipecrv): cancel the token (through the cst) on Ctrl-C
     let token = cst.token();
 
+    // Load .env-file if it exists. Ignore the result since we don't care about its absence.
+    let _ = dotenvy::dotenv();
+
     let cli = match Cli::try_parse() {
         Ok(cli) => {
             // Continue as normal


### PR DESCRIPTION
The dotenvy dependency was added to the dbt-sa-cli crate to read the caller's .env file and modify the environment prior to parsing the CLI arguments. This is useful for many workflows, as callers may have their own configurations stored in a .env file.