### PR TITLE
Workflow: Fix check run approval

### DIFF
--- a/.github/workflows/auto-public-pr-copybara.yml
+++ b/.github/workflows/auto-public-pr-copybara.yml
@@ -19,7 +19,7 @@ env:
   CI_LABEL: "ci:approve-public-fork-ci"
 
 jobs:
-  check-run-approval:
+  check_run_approval:
       permissions:
           pull-requests: write
           contents: read


### PR DESCRIPTION
The name of the job should have been using `_`.