### PR TITLE
Handle Ctrl‑C in dbt-sa-cli by cancelling the runtime token

### DIFF
--- a/.changes/unreleased/Fixes-20251024-021900.yaml
+++ b/.changes/unreleased/Fixes-20251024-021900.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: 'dbt-sa-cli: handle Ctrl-C by cancelling the runtime token'
+time: 2025-10-24T02:19:00Z
+custom:
+    author: RyutoYoda
+    issue: ""
+    project: dbt-fusion


### PR DESCRIPTION
## Summary
- make `dbt-sa-cli` respond to Ctrl-C by cancelling the shared `CancellationTokenSource`
- launch a Tokio task that listens for `tokio::signal::ctrl_c()` and invokes `cancel()`
- keep regular CLI execution unchanged, only affecting the interruption path
- emit a warning (without aborting) if the Ctrl-C listener cannot be installed on the platform

## Testing
- cargo test
  - NOTE: `dbt-test-utils/tests/all_tests.rs` still fails locally with  
    `FsError { … "Failed to set-up tracing" … }`. This is a pre-existing issue  
    unrelated to this change; all other tests pass.
