### PR TITLE
Pin GitHub Actions to specific SHAs (2 actions in 2 files)

### DIFF
--- a/.github/workflows/auto-public-pr-copybara.yml
+++ b/.github/workflows/auto-public-pr-copybara.yml
@@ -56,7 +56,7 @@ jobs:
         username: fa-assistant
         password: ${{ secrets.IT_DBT_FUSION_READONLY_PULLREQUESTS }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4
 
       - name: Configure GitHub auth via ~/.netrc
         run: |

--- a/.github/workflows/enforce-branch-protections.yml
+++ b/.github/workflows/enforce-branch-protections.yml
@@ -80,6 +80,6 @@ jobs:
 
       - name: "Fail job if signed commits are missing"
         if: steps.signed-commits.outputs.signed-commits == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # actions/github-script@v7
         with:
             script: core.setFailed('Signed commits are required to merge.')


### PR DESCRIPTION
## 📌 Pin GitHub Actions to Specific SHAs

This PR updates GitHub Actions references from tags/branches to specific commit SHAs for improved security and reproducibility.

### 📊 Summary
- **Files changed**: 2
- **Actions pinned**: 2

### 📝 Changes by file

#### `.github/workflows/enforce-branch-protections.yml`

- 📌 `actions/github-script@v7` → `actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # actions/github-script@v7`

#### `.github/workflows/auto-public-pr-copybara.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # actions/checkout@v4`

