### PR TITLE
cleanup changelogs

### DIFF
--- a/.changes/unreleased/Features-20250818-092411.yaml
+++ b/.changes/unreleased/Features-20250818-092411.yaml
@@ -1,3 +1,0 @@
-kind: Features
-body: support unit test input SQL format
-time: 2025-08-18T09:24:11.122228802-07:00

--- a/.changes/unreleased/Features-20250821-114947.yaml
+++ b/.changes/unreleased/Features-20250821-114947.yaml
@@ -1,3 +1,0 @@
-kind: Features
-body: Custom Materializations
-time: 2025-08-21T11:49:47.30790228-07:00

--- a/.changes/unreleased/Features-20250904-070504.yaml
+++ b/.changes/unreleased/Features-20250904-070504.yaml
@@ -1,7 +1,0 @@
-kind: Features
-body: Add Yaml source location to test status output
-time: 2025-09-04T07:05:04.140202651-07:00
-custom:
-    author: sadboy
-    issue: ""
-    project: dbt-fusion

--- a/.changes/unreleased/Features-20250909-182347.yaml
+++ b/.changes/unreleased/Features-20250909-182347.yaml
@@ -1,7 +1,0 @@
-kind: Features
-body: '[adapters] [bigquery] Implemented information schema.'
-time: 2025-09-09T18:23:47.584621+03:00
-custom:
-    author: dbtagarovat
-    issue: "539"
-    project: dbt-fusion

--- a/.changes/unreleased/Fixes-20250910-190814.yaml
+++ b/.changes/unreleased/Fixes-20250910-190814.yaml
@@ -1,7 +1,0 @@
-kind: Fixes
-body: (adapters) support fetch on adapter.execute
-time: 2025-09-10T19:08:14.966499357-07:00
-custom:
-    author: xuliangs
-    issue: ""
-    project: dbt-fusion

--- a/.changes/unreleased/Fixes-20250916-123207.yaml
+++ b/.changes/unreleased/Fixes-20250916-123207.yaml
@@ -1,7 +1,0 @@
-kind: Fixes
-body: Fix the DbtIncrementalStrategy enum to take into account custom strategies.
-time: 2025-09-16T12:32:07.624849723-07:00
-custom:
-    author: xuliangs
-    issue: "762"
-    project: dbt-fusion

--- a/.changes/unreleased/Fixes-20250918-003644.yaml
+++ b/.changes/unreleased/Fixes-20250918-003644.yaml
@@ -1,7 +1,0 @@
-kind: Fixes
-body: populates AdapterResponse fields, for Snowflake pass query_id
-time: 2025-09-18T00:36:44.475887904-07:00
-custom:
-    author: xuliangs
-    issue: ""
-    project: dbt-fusion

--- a/.changes/unreleased/Fixes-20250922-100627.yaml
+++ b/.changes/unreleased/Fixes-20250922-100627.yaml
@@ -1,7 +1,0 @@
-kind: Fixes
-body: Enable fusion to read pre/post hook fields from dbt-mantle/dbt-core manifests.
-time: 2025-09-22T10:06:27.006700887-07:00
-custom:
-    author: lottaquestions
-    issue: ""
-    project: dbt-fusion

--- a/.changes/unreleased/Fixes-20250928-154041.yaml
+++ b/.changes/unreleased/Fixes-20250928-154041.yaml
@@ -1,7 +1,0 @@
-kind: Fixes
-body: Fixed wrong error locations on Yaml map keys
-time: 2025-09-28T15:40:41.808014529Z
-custom:
-    author: sadboy
-    issue: "809"
-    project: dbt-fusion

--- a/.changes/unreleased/Fixes-20251004-001906.yaml
+++ b/.changes/unreleased/Fixes-20251004-001906.yaml
@@ -1,7 +1,0 @@
-kind: Fixes
-body: 'Manifest: fix `original_file_path` field for generic data tests'
-time: 2025-10-04T00:19:06.074392863Z
-custom:
-    author: sadboy
-    issue: ""
-    project: dbt-fusion

--- a/.changes/unreleased/Under the Hood-20251001-140650.yaml
+++ b/.changes/unreleased/Under the Hood-20251001-140650.yaml
@@ -1,7 +1,0 @@
-kind: Under the Hood
-body: Refactored get_columns_in_relation for BaseAdapter to no longer use jinja value
-time: 2025-10-01T14:06:50.288563+03:00
-custom:
-    author: dbtagarovat
-    issue: ""
-    project: dbt-fusion

--- a/.changes/unreleased/Under the Hood-20251002-182246.yaml
+++ b/.changes/unreleased/Under the Hood-20251002-182246.yaml
@@ -1,7 +1,0 @@
-kind: Under the Hood
-body: extracted parameter passing in funcs for expand target column types
-time: 2025-10-02T18:22:46.296992+03:00
-custom:
-    author: dbtagarovat
-    issue: ""
-    project: dbt-fusion


### PR DESCRIPTION
These changelogs are released via the internal tooling but were never cleaned up.  This removes them.  This does not been to be synced.