### PR TITLE
suppress decorative header in list output when --quiet is used

### DIFF
--- a/.changes/unreleased/Fixes-20260108-142754.yaml
+++ b/.changes/unreleased/Fixes-20260108-142754.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Suppress decorative header in dbtf list output when --quiet is used
+time: 2026-01-08T14:27:54.65576+09:00
+custom:
+    author: yu-iskw
+    issue: none
+    project: dbt-fusion

--- a/crates/dbt-common/src/tracing/layers/tui_layer.rs
+++ b/crates/dbt-common/src/tracing/layers/tui_layer.rs
@@ -989,11 +989,13 @@ impl TuiLayer {
 
                 // Emit header once before first list item
                 if !self.list_header_emitted.swap(true, Ordering::Relaxed) {
-                    let header =
-                        format_delimiter(SELECTED_NODES_TITLE, self.max_term_line_width, true);
-                    stdout
-                        .write_all(format!("{}\n", header).as_bytes())
-                        .expect("failed to write header to stdout");
+                    if self.show_options.contains(&ShowOptions::Nodes) {
+                        let header =
+                            format_delimiter(SELECTED_NODES_TITLE, self.max_term_line_width, true);
+                        stdout
+                            .write_all(format!("{}\n", header).as_bytes())
+                            .expect("failed to write header to stdout");
+                    }
                 }
 
                 // Print list item content

--- a/crates/dbt-sa-cli/src/dbt_sa_clap.rs
+++ b/crates/dbt-sa-cli/src/dbt_sa_clap.rs
@@ -434,7 +434,9 @@ impl ListArgs {
     pub fn to_eval_args(&self, arg: SystemArgs, in_dir: &Path, out_dir: &Path) -> EvalArgs {
         let mut eval_args = self.common_args.to_eval_args(arg, in_dir, out_dir);
         eval_args.phase = Phases::List;
-        eval_args.io.show.insert(ShowOptions::Nodes);
+        if !self.common_args.quiet {
+            eval_args.io.show.insert(ShowOptions::Nodes);
+        }
         eval_args.output_keys = self.output_keys.clone();
         if let Some(resource_type) = self.resource_type {
             eval_args.resource_types = vec![resource_type];


### PR DESCRIPTION
Solves #1173 

- Updated TuiLayer to conditionally emit the header based on the presence of ShowOptions::Nodes.
- Modified ListArgs to ensure nodes are only shown when not in quiet mode.
- Added tests to verify the behavior of the nodes option in quiet mode.

This change enhances the user experience by reducing unnecessary output during quiet operations.