### PR TITLE
fix(selector): extract and merge embedded excludes from composite selectors

### DIFF
--- a/crates/dbt-jinja/minijinja-contrib/src/modules/py_datetime/strptime.rs
+++ b/crates/dbt-jinja/minijinja-contrib/src/modules/py_datetime/strptime.rs
@@ -104,7 +104,7 @@ impl TimeRE {
             )
         })?;
         let replacement = |caps: &Captures| -> Result<String, Error> {
-            let directive = &caps.get_match().as_str()[1..];
+            let directive = &caps.get(0).unwrap().as_str()[1..];
             self.directives.get(directive).map_or(
                 Err(Error::new(
                     ErrorKind::InvalidArgument,


### PR DESCRIPTION
Solves https://github.com/dbt-labs/dbt-fusion/issues/1279

- Implement `SelectExpression::extract_exclude` to pull `Exclude` variants out of complex boolean expressions.
- Update `resolve_final_selectors` to use extracted excludes and merge them with CLI-provided excludes using an OR relationship.
- Fix `parse_composite` to simplify single-item include expressions.
- Fix a regression in `py_datetime/strptime.rs` regarding regex capture groups.
- Add comprehensive unit tests for exclude extraction and selector resolution.


## Before Fix (The Bug)

In the previous implementation, `exclude` blocks within composite selectors (like `intersection`) were incorrectly embedded directly into the selection expression as an `And` block. This caused the `exclude` to be treated as a required condition for selection rather than a post-filter.

```mermaid
graph TD
    subgraph SelectorParsing [Selector Parsing]
        YAML["selectors.yml"] -->|"parse_composite()"| AndExpr["SelectExpression::And"]
        AndExpr -->|"Child 1"| Inc["Include Pattern"]
        AndExpr -->|"Child 2"| Exc["SelectExpression::Exclude"]
    end

    subgraph Resolution [Resolution Phase]
        AndExpr -->|"Resolved as"| RS_Inc["ResolvedSelector.include"]
        CLI_Exc["CLI --exclude"] -->|"Optional"| RS_Exc["ResolvedSelector.exclude"]
    end

    subgraph Selection [Selection Logic]
        RS_Inc -->|"Evaluated as AND condition"| Nodes["Selected Nodes"]
        note["If Exclude pattern matches nothing (e.g. typo),<br/>the AND condition fails and 0 nodes are selected."]
    end
```

## After Fix (The Corrected Behavior)

The fix introduces a normalization step using `extract_exclude()`. This method recursively extracts excludes from `And` expressions but **stops at `Or` (union) boundaries** to preserve branch-local semantics.

### Key Logic: Semantic Preservation

By stopping at `Or` nodes, we ensure that an expression like `(A AND NOT C) OR B` remains unchanged. If we pulled `C` out globally, it would become `(A OR B) AND NOT C`, which would incorrectly exclude nodes matching `C` from branch `B`.

```mermaid
graph TD
    subgraph SelectorParsing2 [Selector Parsing]
        YAML2["selectors.yml"] -->|"parse_composite()"| Root["SelectExpression Tree"]
    end

    subgraph Normalization [Normalization Phase: extract_exclude]
        Root -->|"Match And"| AndBranch["Split Exclude from Include"]
        Root -->|"Match Or"| OrBranch["Preserve As-Is (Stop Recursion)"]

        AndBranch -->|"Cleaned"| CleanedInc["Cleaned Include"]
        AndBranch -->|"Extracted"| ExtractedExc["Extracted Exclude"]
        OrBranch -->|"Returned as"| CleanedInc
    end

    subgraph Resolution2 [Resolution Phase]
        CleanedInc --> RS_Inc2["ResolvedSelector.include"]
        ExtractedExc -->|"Merge (OR)"| CombinedExc["Final Exclude"]
        CLI_Exc2["CLI --exclude"] -->|"Merge (OR)"| CombinedExc
        CombinedExc --> RS_Exc2["ResolvedSelector.exclude"]
    end

    subgraph Selection2 [Selection Logic]
        RS_Inc2 -->|"Initial Selection"| Nodes2["Included Nodes"]
        RS_Exc2 -->|"Post-filtering (Subtraction)"| FinalNodes["Final Result"]
        Nodes2 -.->|"Exclude Set"| FinalNodes
        note2["Exclude patterns are applied as a post-filter.<br/>Typoes in exclude patterns match nothing,<br/>leaving the included set intact."]
    end
```
