### PR TITLE
fix(dbt-common): update jq installation to dynamically fetch latest version during setup

### DIFF
--- a/.changes/unreleased/Fixes-20260226-235742.yaml
+++ b/.changes/unreleased/Fixes-20260226-235742.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: '[dbt-common] Update jq installation to dynamically fetch latest version during setup'
+time: 2026-02-26T23:57:42.094184018+07:00
+custom:
+    author: tlm365
+    issue: "1019"
+    project: dbt-fusion

--- a/crates/dbt-common/assets/install.sh
+++ b/crates/dbt-common/assets/install.sh
@@ -55,14 +55,24 @@ need() {
     fi
 }
 
+get_latest_jq_version() {
+    _latest_version=$(curl -sL https://api.github.com/repos/jqlang/jq/releases/latest | grep '"tag_name":' | sed -E 's/.*"jq-([^"]+)".*/\1/')
+
+    if [ -z "$_latest_version" ]; then
+        echo "1.8.1" # Hardcode fallback version
+    else
+        echo "$_latest_version"
+    fi
+}
+
 # Function to install jq automatically
 install_jq() {
-    jq_version="1.7.1"
+    jq_version=$(get_latest_jq_version)
     jq_url=""
     jq_binary_name="jq"
     temp_dir=""
     
-    log_grey "jq not found, installing automatically..."
+    log_grey "jq not found, installing automatically (version $jq_version) ..."
     
     # Detect platform for jq download
     os=$(uname -s | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
## Description
Fixes #1019.

This PR updates the `install_jq` shell function to dynamically fetch and install the latest version of `jq` instead of hardcoding a specific version. 

The previously hardcoded version (`1.7.1`) currently has known CVEs. By dynamically fetching the latest release from the official GitHub repository, we ensure that new environments are provisioned with the latest security patches automatically, improving overall infrastructure security posture.

## Key Changes
* **Dynamic Version Fetching:** Added a mechanism to call the GitHub API (`api.github.com/repos/jqlang/jq/releases/latest`) to parse and extract the latest stable version tag.
* **Resilience & Fallback:** If the GitHub API request fails (e.g., due to rate limits or network issues), the script will safely default back to installing version `1.8.1` (latest at the moment, already fix the CVE mentioned in the issue `1019`).