### PR TITLE
Add optional ResultStore param to build_compile_and_run_base_context and extend_base_context_stateful_fn

### DIFF
--- a/.changes/unreleased/Under the Hood-20260320-185014.yaml
+++ b/.changes/unreleased/Under the Hood-20260320-185014.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: '`build_compile_and_run_base_context`, `extend_base_context_stateful_fn`, and `build_run_node_context` now accept an `Option<ResultStore>` parameter so callers can inject a shared store instead of allocating a private one'
+time: 2026-03-20T18:50:14.799749+01:00
+custom:
+    author: thejens
+    issue: "1291"
+    project: dbt-fusion

--- a/crates/dbt-jinja-utils/src/phases/compile_and_run_context.rs
+++ b/crates/dbt-jinja-utils/src/phases/compile_and_run_context.rs
@@ -66,12 +66,16 @@ impl Object for DummyConfig {
 }
 
 /// Configure the Jinja environment for the compile phase.
+///
+/// Pass `Some(store)` to share a `ResultStore` with the context; `None` creates
+/// a private default store.
 pub fn build_compile_and_run_base_context(
     node_resolver: Arc<dyn NodeResolverTracker>,
     package_name: &str,
     nodes: &Nodes,
     runtime_config: Arc<DbtRuntimeConfig>,
     namespace_keys: Vec<String>,
+    result_store: Option<ResultStore>,
 ) -> BTreeMap<String, MinijinjaValue> {
     let mut ctx = BTreeMap::new();
     let config = DummyConfig {};
@@ -165,7 +169,7 @@ pub fn build_compile_and_run_base_context(
         "graph".to_string(),
         MinijinjaValue::from_object(LazyFlatGraph::new(nodes)),
     );
-    let result_store = ResultStore::default();
+    let result_store = result_store.unwrap_or_default();
     ctx.insert(
         "store_result".to_owned(),
         MinijinjaValue::from_function(result_store.store_result()),
@@ -1050,9 +1054,56 @@ impl Object for LazyFlatGraph {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dbt_adapter::load_store::ResultStore;
     use dbt_schemas::state::DummyNodeResolverTracker;
     use dbt_test_utils::TestEnvGuard;
+    use minijinja::Environment;
     use std::env;
+
+    fn make_base_context(
+        result_store: Option<ResultStore>,
+    ) -> BTreeMap<String, MinijinjaValue> {
+        let node_resolver = Arc::new(DummyNodeResolverTracker);
+        let nodes = Nodes::default();
+        let runtime_config = Arc::new(DbtRuntimeConfig::default());
+        build_compile_and_run_base_context(
+            node_resolver,
+            "test_pkg",
+            &nodes,
+            runtime_config,
+            vec![],
+            result_store,
+        )
+    }
+
+    fn render_with_ctx(ctx: &BTreeMap<String, MinijinjaValue>, template: &str) -> String {
+        let mut env = Environment::new();
+        for (k, v) in ctx {
+            env.add_global(k.clone(), v.clone());
+        }
+        env.render_str(template, minijinja::Value::UNDEFINED, &[])
+            .expect("render failed")
+    }
+
+    #[test]
+    fn test_result_store_none_creates_private_store() {
+        let ctx = make_base_context(None);
+        assert!(ctx.contains_key("store_result"), "store_result missing from context");
+        assert!(ctx.contains_key("load_result"), "load_result missing from context");
+        let out = render_with_ctx(&ctx, "{{ load_result('k') is none }}");
+        assert_eq!(out, "True");
+    }
+
+    #[test]
+    fn test_result_store_some_shares_store_with_caller() {
+        let store = ResultStore::default();
+        store
+            .store_result()(&[MinijinjaValue::from("sentinel"), MinijinjaValue::from("OK")])
+            .expect("store_result failed");
+        let ctx = make_base_context(Some(store));
+        let out = render_with_ctx(&ctx, "{{ load_result('sentinel') is not none }}");
+        assert_eq!(out, "True");
+    }
 
     #[test]
     fn test_dbt_metadata_envs_populated_from_env() {
@@ -1080,6 +1131,7 @@ mod tests {
             &nodes,
             runtime_config,
             vec![],
+            None,
         );
 
         // Cleanup env to avoid side effects

--- a/crates/dbt-jinja-utils/src/phases/run/run_node_context.rs
+++ b/crates/dbt-jinja-utils/src/phases/run/run_node_context.rs
@@ -199,13 +199,17 @@ async fn extend_with_model_context<S: Serialize>(
     base_context.insert("connection_name".to_owned(), MinijinjaValue::from(""));
 }
 
-/// Extend the base context with stateful functions
+/// Extend the base context with stateful functions.
+///
+/// Pass `Some(store)` to share a `ResultStore` with the context; `None` creates
+/// a private default store.
 pub fn extend_base_context_stateful_fn(
     base_context: &mut BTreeMap<String, MinijinjaValue>,
     root_project_name: &str,
     packages: BTreeSet<String>,
+    result_store: Option<ResultStore>,
 ) {
-    let result_store = ResultStore::default();
+    let result_store = result_store.unwrap_or_default();
     base_context.insert(
         "store_result".to_owned(),
         MinijinjaValue::from_function(result_store.store_result()),
@@ -252,10 +256,16 @@ pub async fn build_run_node_context<S: Serialize>(
     resource_type: NodeType,
     sql_header: Option<MinijinjaValue>,
     packages: BTreeSet<String>,
+    result_store: Option<ResultStore>,
 ) -> BTreeMap<String, MinijinjaValue> {
     // Build model-specific context
     let mut context = base_context.clone();
-    extend_base_context_stateful_fn(&mut context, &common_attr.package_name, packages);
+    extend_base_context_stateful_fn(
+        &mut context,
+        &common_attr.package_name,
+        packages,
+        result_store,
+    );
 
     extend_with_model_context(
         &mut context,
@@ -525,5 +535,44 @@ fn submit_python_job_context_fn()
             &[parsed_model.clone(), MinijinjaValue::from(compiled_code)],
             &[],
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dbt_adapter::load_store::ResultStore;
+    use minijinja::Environment;
+
+    fn render_with_ctx(ctx: &BTreeMap<String, MinijinjaValue>, template: &str) -> String {
+        let mut env = Environment::new();
+        for (k, v) in ctx {
+            env.add_global(k.clone(), v.clone());
+        }
+        env.render_str(template, minijinja::Value::UNDEFINED, &[])
+            .expect("render failed")
+    }
+
+    #[test]
+    fn test_extend_none_creates_private_store() {
+        let mut ctx = BTreeMap::new();
+        extend_base_context_stateful_fn(&mut ctx, "test_pkg", BTreeSet::new(), None);
+        assert!(ctx.contains_key("store_result"), "store_result missing");
+        assert!(ctx.contains_key("load_result"), "load_result missing");
+        assert!(ctx.contains_key("store_raw_result"), "store_raw_result missing");
+        let out = render_with_ctx(&ctx, "{{ load_result('k') is none }}");
+        assert_eq!(out, "True");
+    }
+
+    #[test]
+    fn test_extend_some_shares_store_with_caller() {
+        let store = ResultStore::default();
+        store
+            .store_result()(&[MinijinjaValue::from("sentinel"), MinijinjaValue::from("OK")])
+            .expect("store_result failed");
+        let mut ctx = BTreeMap::new();
+        extend_base_context_stateful_fn(&mut ctx, "test_pkg", BTreeSet::new(), Some(store));
+        let out = render_with_ctx(&ctx, "{{ load_result('sentinel') is not none }}");
+        assert_eq!(out, "True");
     }
 }

--- a/crates/dbt-parser/src/renderer.rs
+++ b/crates/dbt-parser/src/renderer.rs
@@ -817,6 +817,7 @@ async fn process_model_chunk_for_unsafe_detection<T: InternalDbtNodeAttributes +
         &Nodes::default(),
         runtime_config.clone(),
         namespace_keys,
+        None,
     );
     silence_base_context(&mut render_base_context);
 


### PR DESCRIPTION
Fixes #1291.

Both functions unconditionally created a `ResultStore::default()` and discarded it whenever the caller needed their own. This just adds an `Option<ResultStore>` param — `Some` uses the provided store, `None` falls back to `default()` so existing callers are unaffected.

Also threaded the param through `build_run_node_context` since that's how most callers reach `extend_base_context_stateful_fn`.

Added a couple of tests to verify both paths work.