### PR TITLE
feat: add release lifecycle tracker workflow

### DIFF
--- a/.github/workflows/release-awaiting.yml
+++ b/.github/workflows/release-awaiting.yml
@@ -1,0 +1,56 @@
+# **what?**
+# Immediately labels a dbt-fusion issue as awaiting release when it is closed.
+
+# **why?**
+# Support customers subscribe to issues to track fixes. When an issue closes
+# (fix merged), they need to know it's not live yet — average ~1 week to release.
+
+# **when?**
+# Whenever any issue in dbt-labs/dbt-fusion is closed.
+
+name: "Release Tracker: Awaiting Release"
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  label-awaiting-release:
+    name: "Label issue as awaiting release"
+    runs-on: ubuntu-latest
+    # Skip if any release/* label is already present (idempotent)
+    if: |
+      !contains(toJson(github.event.issue.labels.*.name), 'release/awaiting-release') &&
+      !contains(toJson(github.event.issue.labels.*.name), 'release/released') &&
+      !contains(toJson(github.event.issue.labels.*.name), 'release/rolled-back')
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.issue.number;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue,
+              labels: ['release/awaiting-release'],
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue,
+              body: [
+                '## Fix Merged — Awaiting Release',
+                '',
+                'This issue has been resolved and the fix is merged, but it has not yet shipped in a release.',
+                '',
+                'Releases typically go out within **~1 week**. We\'ll update this issue with the exact version once it\'s live.',
+                '',
+                'Subscribe to this issue to get notified when the fix is available.',
+              ].join('\n'),
+            });


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release-awaiting.yml` which fires whenever a `dbt-fusion` issue is closed
- Immediately applies `release/awaiting-release` label and posts a comment telling subscribed customers the fix is merged but not yet live (~1 week typical release cadence)
- Skips idempotently if any `release/*` label is already present

## Context

Part of a larger release lifecycle tracking system. The complementary workflows (marking issues as released when a version hits the `latest` track, and marking them rolled-back when a release is flagged bad) live in `dbt-labs/fs` and reach across via PAT.

The three labels (`release/awaiting-release`, `release/released`, `release/rolled-back`) have already been created in this repo.

## Test plan

- [ ] Merge this PR
- [ ] Create a test issue, close it, verify `release/awaiting-release` label and comment appear within seconds
- [ ] Close an issue that already has `release/released` — confirm the workflow skips it (idempotency check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)