### PR TITLE
fix(release-tracker): only label issues closed by a PR, skip EPICs

### DIFF
--- a/.github/workflows/release-awaiting.yml
+++ b/.github/workflows/release-awaiting.yml
@@ -6,7 +6,7 @@
 # (fix merged), they need to know it's not live yet — average ~1 week to release.
 
 # **when?**
-# Whenever any issue in dbt-labs/dbt-fusion is closed.
+# Whenever any issue in dbt-labs/dbt-fusion is closed by a merged PR.
 
 name: "Release Tracker: Awaiting Release"
 
@@ -21,17 +21,53 @@ jobs:
   label-awaiting-release:
     name: "Label issue as awaiting release"
     runs-on: ubuntu-latest
-    # Skip if any release/* label is already present (idempotent)
+    # Skip if:
+    #   - already has any release/* label (idempotent)
+    #   - closed as won't-fix / not planned
+    #   - title starts with [EPIC] (epics are not individual fix issues)
     if: |
+      github.event.issue.state_reason == 'completed' &&
+      !startsWith(github.event.issue.title, '[EPIC]') &&
       !contains(toJson(github.event.issue.labels.*.name), 'release/awaiting-release') &&
       !contains(toJson(github.event.issue.labels.*.name), 'release/released') &&
       !contains(toJson(github.event.issue.labels.*.name), 'release/rolled-back')
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@60a0d83039f74a4aee543508d2ffcb1c3799cdea  # actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const issue = context.issue.number;
+
+            // Verify the issue was actually closed by a PR (not manually closed).
+            // Uses a targeted GraphQL query — only fetches CLOSED_EVENT items,
+            // so this is a single cheap round-trip with minimal payload.
+            const result = await github.graphql(`
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  issue(number: $number) {
+                    timelineItems(last: 5, itemTypes: [CLOSED_EVENT]) {
+                      nodes {
+                        ... on ClosedEvent {
+                          closer { __typename }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: issue,
+            });
+
+            const closedByPR = result.repository.issue.timelineItems.nodes
+              .some(e => e.closer?.__typename === 'PullRequest');
+
+            if (!closedByPR) {
+              core.notice(`Issue #${issue} was not closed by a PR — skipping`);
+              return;
+            }
 
             await github.rest.issues.addLabels({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

- Adds `state_reason == 'completed'` and `!startsWith(title, '[EPIC]')` to the job `if` condition — these are evaluated before a runner is spun up, so filtered issues cost nothing
- Adds a GraphQL `CLOSED_EVENT` check inside the script to confirm the issue was closed by a PR (not manually) — single round-trip, fetches only close events with `closer.__typename`

## Filters (cheapest-first)

| Filter | Where | Cost |
|---|---|---
| `state_reason == 'completed'` | job `if` | free |
| Title doesn't start with `[EPIC]` | job `if` | free |
| Already has a `release/*` label | job `if` | free |
| Closed by a `PullRequest` | GraphQL in script | 1 API call |

🤖 Generated with [Claude Code](https://claude.com/claude-code)