### PR TITLE
feature: exasol connector

### DIFF
--- a/.changes/unreleased/Features-20260417-150000.yaml
+++ b/.changes/unreleased/Features-20260417-150000.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add Exasol database connector via exarrow-rs ADBC driver
+time: 2026-04-17T15:00:00.000000+02:00
+custom:
+    author: marconae
+    issue: ""
+    project: dbt-fusion

--- a/crates/dbt-adapter-core/src/lib.rs
+++ b/crates/dbt-adapter-core/src/lib.rs
@@ -32,6 +32,8 @@ pub enum AdapterType {
     Sidecar,
     /// ClickHouse
     ClickHouse,
+    /// Exasol
+    Exasol,
     /// Athena
     Athena,
     /// Starburst
@@ -59,6 +61,7 @@ pub fn quote_char(adapter_type: AdapterType) -> char {
         Athena | Trino | Starburst => '"',
         Datafusion => '"',
         ClickHouse => '"',
+        Exasol => '"',
         Sidecar => '"',
         Dremio => todo!("Dremio"),
         Oracle => todo!("Oracle"),

--- a/crates/dbt-adapter/src/adapter/adapter_factory.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_factory.rs
@@ -31,6 +31,7 @@ pub fn backend_of(adapter_type: AdapterType) -> Backend {
         AdapterType::Sidecar => Backend::DuckDB,
         AdapterType::Fabric => Backend::SQLServer,
         AdapterType::ClickHouse => todo!("ClickHouse"),
+        AdapterType::Exasol => Backend::Exasol,
         AdapterType::Starburst => todo!("Starburst"),
         AdapterType::Athena => todo!("Athena"),
         AdapterType::Trino => todo!("Trino"),

--- a/crates/dbt-adapter/src/adapter/adapter_impl.rs
+++ b/crates/dbt-adapter/src/adapter/adapter_impl.rs
@@ -182,6 +182,7 @@ impl AdapterImpl {
                             Box::new(FabricMetadataAdapter::new(engine)) as Box<dyn MetadataAdapter>
                         }
                         ClickHouse => todo!("ClickHouse"),
+                        Exasol => todo!("Exasol"),
                         Starburst => todo!("Starburst"),
                         Athena => todo!("Athena"),
                         Trino => todo!("Trino"),
@@ -362,7 +363,7 @@ impl AdapterImpl {
             Redshift => &[Append, DeleteInsert, Merge, Microbatch],
             Fabric => &[Append, DeleteInsert, Merge, Microbatch],
             Salesforce => &[Append, Merge],
-            Spark | ClickHouse | Athena | Starburst | Trino | Datafusion | Dremio | Oracle => {
+            Spark | ClickHouse | Exasol | Athena | Starburst | Trino | Datafusion | Dremio | Oracle => {
                 unimplemented!("valid_incremental_strategies not implemented")
             }
         }
@@ -768,13 +769,13 @@ impl AdapterImpl {
             }
             Replay(
                 adapter_type @ (Postgres | Redshift | Salesforce | Sidecar | DuckDB | Spark
-                | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion
+                | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion
                 | Dremio | Oracle),
                 _,
             )
             | Impl(
                 adapter_type @ (Postgres | Redshift | Salesforce | Sidecar | DuckDB | Spark
-                | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion
+                | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion
                 | Dremio | Oracle),
                 _,
             ) => Err(AdapterError::new(
@@ -791,7 +792,7 @@ impl AdapterImpl {
     ) -> String {
         match adapter_type {
             Snowflake | Redshift | Postgres | Sidecar | Salesforce | DuckDB | Fabric
-            | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
+            | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
                 format!("\"{identifier}\"")
             }
             Bigquery | Databricks | Spark => {
@@ -817,6 +818,7 @@ impl AdapterImpl {
                 DuckDB => "schema_name",
                 Fabric => "schema",
                 ClickHouse => todo!("ClickHouse"),
+                Exasol => todo!("Exasol"),
                 Starburst => todo!("Starburst"),
                 Athena => todo!("Athena"),
                 Trino => todo!("Trino"),
@@ -1076,7 +1078,7 @@ impl AdapterImpl {
                 )])))
             }
             Postgres | Bigquery | Databricks | Redshift | Salesforce | Sidecar | Spark | DuckDB
-            | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
+            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
                 let err = format!(
                     "describe_dynamic_table is not supported by the {} adapter",
                     adapter_type
@@ -1473,7 +1475,7 @@ impl AdapterImpl {
                     "get_columns_in_relation",
                 )
             }
-            Salesforce | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
+            Salesforce | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
                 unimplemented!("get_columns_in_relation not implemented")
             }
         };
@@ -1580,7 +1582,7 @@ impl AdapterImpl {
                     .collect::<Vec<_>>();
                 Ok(columns)
             }
-            Salesforce | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
+            Salesforce | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
                 unimplemented!("get_columns_in_relation not implemented")
             }
         }
@@ -1644,7 +1646,7 @@ impl AdapterImpl {
             }
             Impl(
                 Snowflake | Databricks | Redshift | Salesforce | Postgres | Sidecar | Spark
-                | DuckDB | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+                | DuckDB | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
                 | Oracle,
                 _,
             ) => {
@@ -1689,7 +1691,7 @@ impl AdapterImpl {
             }
             Impl(
                 Postgres | Bigquery | Databricks | Redshift | Sidecar | Spark | DuckDB | Fabric
-                | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio | Oracle,
+                | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio | Oracle,
                 _,
             ) => {
                 // https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/src/dbt/adapters/base/impl.py#L1072
@@ -1869,7 +1871,7 @@ impl AdapterImpl {
                 Ok(none_value())
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Sidecar | Spark
-            | Fabric | DuckDB | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+            | Fabric | DuckDB | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
             | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
@@ -1883,7 +1885,7 @@ impl AdapterImpl {
     ) -> AdapterResult<Vec<String>> {
         match self.adapter_type() {
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Sidecar | Spark
-            | DuckDB | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+            | DuckDB | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
             | Oracle => {
                 // https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/src/dbt/adapters/base/impl.py#L1783
                 let mut result = vec![];
@@ -2062,7 +2064,7 @@ impl AdapterImpl {
 
             // Salesforce
             (
-                Salesforce | Spark | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+                Salesforce | Spark | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
                 | Oracle,
                 _,
             ) => {
@@ -2217,7 +2219,7 @@ impl AdapterImpl {
 
                 Ok(result)
             }
-            Salesforce | Spark | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion
+            Salesforce | Spark | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion
             | Dremio | Oracle => {
                 unimplemented!("grants not implemented")
             }
@@ -2232,7 +2234,7 @@ impl AdapterImpl {
         match self.adapter_type() {
             Bigquery => nest_column_data_types(columns, constraints),
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Sidecar | Spark
-            | DuckDB | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+            | DuckDB | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
             | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
@@ -2344,7 +2346,7 @@ impl AdapterImpl {
                 Ok(none_value())
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Sidecar | Spark
-            | DuckDB | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+            | DuckDB | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
             | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
@@ -2386,7 +2388,7 @@ impl AdapterImpl {
                 }
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Sidecar | Spark
-            | DuckDB | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+            | DuckDB | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
             | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
@@ -2434,7 +2436,7 @@ impl AdapterImpl {
                 Ok(none_value())
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Sidecar | Spark
-            | DuckDB | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+            | DuckDB | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
             | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
@@ -2510,7 +2512,7 @@ impl AdapterImpl {
             }
             Salesforce => todo!("load_dataframe() for the Salesforce adapter"),
             Postgres | Snowflake | Databricks | Redshift | Sidecar | Spark | DuckDB | Fabric
-            | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
+            | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with BigQuery or Salesforce adapter")
             }
         }
@@ -2568,7 +2570,7 @@ impl AdapterImpl {
                 Ok(none_value())
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Sidecar | Spark
-            | DuckDB | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+            | DuckDB | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
             | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
@@ -2745,7 +2747,7 @@ impl AdapterImpl {
             }
             Impl(
                 adapter_type @ (Snowflake | Bigquery | Databricks | Salesforce | Spark | Fabric
-                | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+                | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
                 | Oracle),
                 _,
             ) => {
@@ -2819,7 +2821,7 @@ impl AdapterImpl {
                 }
             }
             adapter_type @ (Postgres | Snowflake | Databricks | Redshift | Salesforce | Sidecar
-            | Spark | DuckDB | Fabric | ClickHouse | Starburst | Athena | Trino
+            | Spark | DuckDB | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino
             | Datafusion | Dremio | Oracle) => {
                 unimplemented!(
                     "is_replaceable is only available with BigQuery adapter, not {}",
@@ -2883,7 +2885,7 @@ impl AdapterImpl {
                 Ok(Value::from_object(validated_config))
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Sidecar | Spark
-            | DuckDB | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+            | DuckDB | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
             | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
@@ -2906,7 +2908,7 @@ impl AdapterImpl {
                 adapter_type,
             ),
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Sidecar | Spark
-            | DuckDB | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+            | DuckDB | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
             | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
@@ -2929,7 +2931,7 @@ impl AdapterImpl {
                 ),
             ),
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Sidecar | Spark
-            | DuckDB | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+            | DuckDB | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
             | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
@@ -2955,7 +2957,7 @@ impl AdapterImpl {
                 Ok(Value::from_serialize(options))
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Sidecar | Spark
-            | DuckDB | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+            | DuckDB | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
             | Oracle => Err(minijinja::Error::new(
                 minijinja::ErrorKind::InvalidOperation,
                 "get_common_options is only available with BigQuery adapter",
@@ -2995,7 +2997,7 @@ impl AdapterImpl {
                 Ok(Value::from(result))
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Sidecar | Spark
-            | DuckDB | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+            | DuckDB | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
             | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
@@ -3066,7 +3068,7 @@ impl AdapterImpl {
                 fabric::list_relations(engine.as_ref(), query_ctx, conn, db_schema, token)
             }
             Impl(
-                adapter_type @ (Postgres | Salesforce | Sidecar | ClickHouse | Starburst | Athena
+                adapter_type @ (Postgres | Salesforce | Sidecar | ClickHouse | Exasol | Starburst | Athena
                 | Trino | Datafusion | Dremio | Oracle),
                 _,
             ) => {
@@ -3145,7 +3147,7 @@ impl AdapterImpl {
                 Ok(Value::from(result))
             }
             Postgres | Snowflake | Bigquery | Redshift | Salesforce | Sidecar | Spark | DuckDB
-            | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
+            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with Databricksadapter")
             }
         }
@@ -3301,7 +3303,7 @@ impl AdapterImpl {
             }
 
             Postgres | Snowflake | Bigquery | Redshift | Salesforce | Sidecar | Spark | DuckDB
-            | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
+            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with Databricks adapter")
             }
         }
@@ -3381,7 +3383,7 @@ impl AdapterImpl {
                 Ok(())
             }
             Postgres | Snowflake | Bigquery | Redshift | Salesforce | Sidecar | Spark | DuckDB
-            | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
+            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with Databricks adapter")
             }
         }
@@ -3457,7 +3459,7 @@ impl AdapterImpl {
                 Ok(!use_managed_iceberg)
             }
             Postgres | Snowflake | Bigquery | Redshift | Salesforce | Sidecar | Spark | DuckDB
-            | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
+            | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio | Oracle => {
                 unimplemented!("only available with Databricks adapter")
             }
         }
@@ -3776,7 +3778,7 @@ impl AdapterImpl {
                 Ok(())
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Sidecar | Spark
-            | DuckDB | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+            | DuckDB | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
             | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
@@ -3829,7 +3831,7 @@ impl AdapterImpl {
                 Ok(None)
             }
             Postgres | Snowflake | Databricks | Redshift | Salesforce | Sidecar | Spark
-            | DuckDB | Fabric | ClickHouse | Starburst | Athena | Trino | Datafusion | Dremio
+            | DuckDB | Fabric | ClickHouse | Exasol | Starburst | Athena | Trino | Datafusion | Dremio
             | Oracle => {
                 unimplemented!("only available with BigQuery adapter")
             }
@@ -4117,7 +4119,7 @@ pub(crate) fn adapter_specific_behavior_flags(adapter_type: AdapterType) -> Vec<
             );
             vec![flag]
         }
-        Postgres | Redshift | Salesforce | Sidecar | Spark | DuckDB | ClickHouse | Starburst
+        Postgres | Redshift | Salesforce | Sidecar | Spark | DuckDB | ClickHouse | Exasol | Starburst
         | Athena | Trino | Datafusion | Dremio | Oracle => vec![],
     }
 }

--- a/crates/dbt-adapter/src/column/column_builder.rs
+++ b/crates/dbt-adapter/src/column/column_builder.rs
@@ -31,6 +31,7 @@ impl ColumnBuilder {
             }
             Fabric => Ok(Self::build_fabric(field, type_ops)),
             ClickHouse => todo!("ClickHouse"),
+            Exasol => todo!("Exasol"),
             Starburst => todo!("Starburst"),
             Athena => todo!("Athena"),
             Trino => todo!("Trino"),
@@ -95,6 +96,7 @@ impl ColumnBuilder {
             ),
             Salesforce => todo!("Salesforce column creation not implemented yet"),
             ClickHouse => todo!("ClickHouse"),
+            Exasol => todo!("Exasol"),
             Starburst => todo!("Starburst"),
             Athena => todo!("Athena"),
             Trino => todo!("Trino"),

--- a/crates/dbt-adapter/src/metadata/get_relation.rs
+++ b/crates/dbt-adapter/src/metadata/get_relation.rs
@@ -73,6 +73,7 @@ pub fn get_relation(
             ))
         }
         AdapterType::ClickHouse => todo!("ClickHouse"),
+        AdapterType::Exasol => todo!("Exasol"),
         AdapterType::Starburst => todo!("Starburst"),
         AdapterType::Athena => todo!("Athena"),
         AdapterType::Trino => todo!("Trino"),

--- a/crates/dbt-adapter/src/relation/factory.rs
+++ b/crates/dbt-adapter/src/relation/factory.rs
@@ -49,6 +49,7 @@ pub fn create_static_relation(
             StaticBaseRelationObject::new(Arc::new(relation_type))
         }
         ClickHouse => todo!("ClickHouse"),
+        Exasol => todo!("Exasol"),
         Starburst => todo!("Starburst"),
         Athena => todo!("Athena"),
         Trino => todo!("Trino"),

--- a/crates/dbt-adapter/src/relation/relation_object.rs
+++ b/crates/dbt-adapter/src/relation/relation_object.rs
@@ -354,6 +354,7 @@ pub fn do_create_relation(
             relation_type,
         )) as Box<dyn BaseRelation>,
         ClickHouse => todo!("ClickHouse"),
+        Exasol => todo!("Exasol"),
         Starburst => todo!("Starburst"),
         Athena => todo!("Athena"),
         Trino => todo!("Trino"),

--- a/crates/dbt-adapter/src/sql_types.rs
+++ b/crates/dbt-adapter/src/sql_types.rs
@@ -169,7 +169,7 @@ impl TypeOps for SATypeOpsImpl {
             // No type transformations have been necessary for the seed operation against
             // these data platforms so far, but this may need to be updated if that changes.
             Postgres | Salesforce | Spark | DuckDB | Fabric => None,
-            ClickHouse | Starburst | Athena | Trino | Dremio | Oracle | Datafusion => {
+            ClickHouse | Exasol | Starburst | Athena | Trino | Dremio | Oracle | Datafusion => {
                 todo!("not yet")
             }
         }
@@ -288,6 +288,7 @@ pub const fn get_field_sql_type_metadata_key(adapter_type: AdapterType) -> &'sta
         AdapterType::DuckDB => todo!(),
         AdapterType::Fabric => FABRIC_METADATA_SQL_TYPE_KEY,
         AdapterType::ClickHouse => todo!(),
+        AdapterType::Exasol => todo!(),
         AdapterType::Starburst => todo!(),
         AdapterType::Athena => todo!(),
         AdapterType::Trino => todo!(),
@@ -341,7 +342,7 @@ impl SdfSchemaBuilder {
                 metadata.get(ARROW_FIELD_COMMENT_METADATA_KEY)
             }
             // no evidence that these drivers store comments in metadata, but just in case
-            Postgres | Snowflake | Salesforce | Sidecar | Fabric | ClickHouse | Starburst
+            Postgres | Snowflake | Salesforce | Sidecar | Fabric | ClickHouse | Exasol | Starburst
             | Athena | Trino | Dremio | Oracle | Datafusion => {
                 metadata.get(ARROW_FIELD_COMMENT_METADATA_KEY)
             }
@@ -379,7 +380,7 @@ impl SdfSchemaBuilder {
         use AdapterType::*;
         match self.adapter_type {
             Bigquery | Redshift | Databricks | Spark | Sidecar | DuckDB | Fabric | ClickHouse
-            | Starburst | Athena | Trino | Dremio | Oracle | Datafusion => {
+            | Exasol | Starburst | Athena | Trino | Dremio | Oracle | Datafusion => {
                 let original_fields = self.original.fields();
                 let mut sdf_fields = Vec::with_capacity(original_fields.len());
                 for field in original_fields {
@@ -743,7 +744,7 @@ pub const fn max_varchar_size(adapter_type: AdapterType) -> Option<usize> {
         Snowflake => Some(16_777_216),
         Redshift => Some(256),
         Postgres | Bigquery | Databricks | Salesforce | Spark | Sidecar | DuckDB | Fabric
-        | ClickHouse | Starburst | Athena | Trino | Dremio | Oracle | Datafusion => None,
+        | ClickHouse | Exasol | Starburst | Athena | Trino | Dremio | Oracle | Datafusion => None,
     }
 }
 
@@ -754,7 +755,7 @@ pub const fn max_varbinary_size(adapter_type: AdapterType) -> Option<usize> {
         Redshift => Some(65_535),
         // TODO: define limits for more systems
         Postgres | Bigquery | Databricks | Salesforce | Spark | Sidecar | DuckDB | Fabric
-        | ClickHouse | Starburst | Athena | Trino | Dremio | Oracle | Datafusion => None,
+        | ClickHouse | Exasol | Starburst | Athena | Trino | Dremio | Oracle | Datafusion => None,
     }
 }
 

--- a/crates/dbt-auth/src/exasol/mod.rs
+++ b/crates/dbt-auth/src/exasol/mod.rs
@@ -1,0 +1,330 @@
+use crate::{AdapterConfig, Auth, AuthError, AuthOutcome, auth_configure_pipeline};
+use database::Builder as DatabaseBuilder;
+use dbt_xdbc::{Backend, database};
+use std::borrow::Cow;
+
+const DEFAULT_HOST: &str = "localhost";
+const DEFAULT_PORT: &str = "8563";
+
+#[derive(Debug)]
+enum ExasolAuthIR<'a> {
+    UserPass {
+        user: &'a str,
+        password: Cow<'a, str>,
+        host: &'a str,
+        port: Cow<'a, str>,
+        schema: Option<&'a str>,
+        encryption: bool,
+        certificate_validation: bool,
+        certificate_fingerprint: Option<&'a str>,
+        connection_timeout: Option<Cow<'a, str>>,
+    },
+}
+
+impl<'a> ExasolAuthIR<'a> {
+    pub fn apply(self, mut builder: DatabaseBuilder) -> Result<DatabaseBuilder, AuthError> {
+        match self {
+            Self::UserPass {
+                user,
+                password,
+                host,
+                port,
+                schema,
+                encryption,
+                certificate_validation,
+                certificate_fingerprint,
+                connection_timeout,
+            } => {
+                let mut uri = format!("exasol://{host}:{port}");
+
+                if let Some(schema) = schema {
+                    uri.push('/');
+                    uri.push_str(schema);
+                }
+
+                let mut params: Vec<String> = Vec::new();
+
+                if !encryption {
+                    params.push("tls=0".to_string());
+                }
+
+                if !certificate_validation {
+                    params.push("validateservercertificate=0".to_string());
+                }
+
+                if let Some(fingerprint) = certificate_fingerprint {
+                    params.push(format!("certificatefingerprint={fingerprint}"));
+                }
+
+                if let Some(timeout) = &connection_timeout {
+                    params.push(format!("timeout={timeout}"));
+                }
+
+                if !params.is_empty() {
+                    uri.push('?');
+                    uri.push_str(&params.join("&"));
+                }
+
+                builder.with_parse_uri(uri)?;
+                builder.with_username(user);
+                builder.with_password(password.as_ref());
+            }
+        }
+
+        Ok(builder)
+    }
+}
+
+fn parse_auth<'a>(config: &'a AdapterConfig) -> Result<ExasolAuthIR<'a>, AuthError> {
+    let encryption = config
+        .get_string("encryption")
+        .map(|s| s != "false" && s != "0" && s != "False")
+        .unwrap_or(true);
+
+    let certificate_validation = config
+        .get_string("certificate_validation")
+        .map(|s| s != "false" && s != "0" && s != "False")
+        .unwrap_or(true);
+
+    let user = config
+        .get_str("user")
+        .ok_or_else(|| AuthError::config("Exasol requires 'user' in profile configuration"))?;
+
+    let password = config
+        .get_string("password")
+        .ok_or_else(|| AuthError::config("Exasol requires 'password' in profile configuration"))?;
+
+    Ok(ExasolAuthIR::UserPass {
+        user,
+        password,
+        host: config.get_str("host").unwrap_or(DEFAULT_HOST),
+        port: config
+            .get_string("port")
+            .unwrap_or(Cow::Borrowed(DEFAULT_PORT)),
+        schema: config.get_str("schema"),
+        encryption,
+        certificate_validation,
+        certificate_fingerprint: config.get_str("certificate_fingerprint"),
+        connection_timeout: config.get_string("connection_timeout"),
+    })
+}
+
+fn apply_connection_args(
+    _config: &AdapterConfig,
+    builder: DatabaseBuilder,
+) -> Result<DatabaseBuilder, AuthError> {
+    Ok(builder)
+}
+
+pub struct ExasolAuth;
+
+impl Auth for ExasolAuth {
+    fn backend(&self) -> Backend {
+        Backend::Exasol
+    }
+
+    fn configure(&self, config: &AdapterConfig) -> Result<AuthOutcome, AuthError> {
+        auth_configure_pipeline!(self.backend(), &config, parse_auth, apply_connection_args)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_options::uri_value;
+    use dbt_test_primitives::assert_contains;
+    use dbt_yaml::Mapping;
+    use dbt_yaml::Value as YmlValue;
+
+    #[test]
+    fn test_defaults_with_required_fields() {
+        let config = Mapping::from_iter([
+            ("user".into(), "sys".into()),
+            ("password".into(), "exasol".into()),
+        ]);
+
+        let builder = ExasolAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect("configure")
+            .builder;
+
+        let uri = uri_value(&builder);
+        assert_contains!(&uri, "exasol://localhost:8563");
+    }
+
+    #[test]
+    fn test_custom_host_and_port() {
+        let config = Mapping::from_iter([
+            ("host".into(), "exasol.prod.internal".into()),
+            ("port".into(), "9563".into()),
+            ("user".into(), "analytics".into()),
+            ("password".into(), "secret".into()),
+        ]);
+
+        let builder = ExasolAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect("configure")
+            .builder;
+
+        let uri = uri_value(&builder);
+        assert_contains!(&uri, "exasol://exasol.prod.internal:9563");
+    }
+
+    #[test]
+    fn test_schema_in_uri() {
+        let config = Mapping::from_iter([
+            ("user".into(), "sys".into()),
+            ("password".into(), "exasol".into()),
+            ("schema".into(), "MY_SCHEMA".into()),
+        ]);
+
+        let builder = ExasolAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect("configure")
+            .builder;
+
+        let uri = uri_value(&builder);
+        assert_contains!(&uri, "exasol://localhost:8563/MY_SCHEMA");
+    }
+
+    #[test]
+    fn test_encryption_disabled() {
+        let config = Mapping::from_iter([
+            ("user".into(), "sys".into()),
+            ("password".into(), "exasol".into()),
+            ("encryption".into(), "false".into()),
+        ]);
+
+        let builder = ExasolAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect("configure")
+            .builder;
+
+        let uri = uri_value(&builder);
+        assert_contains!(&uri, "tls=0");
+    }
+
+    #[test]
+    fn test_encryption_disabled_as_yaml_boolean() {
+        let config: Mapping = dbt_yaml::from_str(
+            r#"
+user: sys
+password: exasol
+encryption: false
+"#,
+        )
+        .expect("parse yaml");
+
+        let builder = ExasolAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect("configure")
+            .builder;
+
+        let uri = uri_value(&builder);
+        assert_contains!(&uri, "tls=0");
+    }
+
+    #[test]
+    fn test_certificate_validation_disabled() {
+        let config = Mapping::from_iter([
+            ("user".into(), "sys".into()),
+            ("password".into(), "exasol".into()),
+            ("certificate_validation".into(), "false".into()),
+        ]);
+
+        let builder = ExasolAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect("configure")
+            .builder;
+
+        let uri = uri_value(&builder);
+        assert_contains!(&uri, "validateservercertificate=0");
+    }
+
+    #[test]
+    fn test_certificate_fingerprint() {
+        let config = Mapping::from_iter([
+            ("user".into(), "sys".into()),
+            ("password".into(), "exasol".into()),
+            (
+                "certificate_fingerprint".into(),
+                "AB:CD:EF:01:23:45".into(),
+            ),
+        ]);
+
+        let builder = ExasolAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect("configure")
+            .builder;
+
+        let uri = uri_value(&builder);
+        assert_contains!(&uri, "certificatefingerprint=AB:CD:EF:01:23:45");
+    }
+
+    #[test]
+    fn test_connection_timeout() {
+        let config = Mapping::from_iter([
+            ("user".into(), "sys".into()),
+            ("password".into(), "exasol".into()),
+            ("connection_timeout".into(), YmlValue::number(30i64.into())),
+        ]);
+
+        let builder = ExasolAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect("configure")
+            .builder;
+
+        let uri = uri_value(&builder);
+        assert_contains!(&uri, "timeout=30");
+    }
+
+    #[test]
+    fn test_numeric_port() {
+        let config = Mapping::from_iter([
+            ("user".into(), "sys".into()),
+            ("password".into(), "exasol".into()),
+            ("port".into(), YmlValue::number(9563i64.into())),
+        ]);
+
+        let builder = ExasolAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect("configure")
+            .builder;
+
+        let uri = uri_value(&builder);
+        assert_contains!(&uri, "exasol://localhost:9563");
+    }
+
+    #[test]
+    fn test_missing_user_returns_error() {
+        let config = Mapping::from_iter([("password".into(), "exasol".into())]);
+
+        let result = ExasolAuth {}.configure(&AdapterConfig::new(config));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_missing_password_returns_error() {
+        let config = Mapping::from_iter([("user".into(), "sys".into())]);
+
+        let result = ExasolAuth {}.configure(&AdapterConfig::new(config));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_encryption_enabled_by_default_no_tls_param() {
+        let config = Mapping::from_iter([
+            ("user".into(), "sys".into()),
+            ("password".into(), "exasol".into()),
+        ]);
+
+        let builder = ExasolAuth {}
+            .configure(&AdapterConfig::new(config))
+            .expect("configure")
+            .builder;
+
+        let uri = uri_value(&builder);
+        // When encryption is enabled (default), no tls param should be present
+        assert!(!uri.contains("tls="));
+    }
+}

--- a/crates/dbt-auth/src/lib.rs
+++ b/crates/dbt-auth/src/lib.rs
@@ -12,6 +12,7 @@ mod bigquery;
 mod clickhouse;
 mod databricks;
 mod duckdb;
+mod exasol;
 #[cfg(test)]
 mod flock;
 mod postgres;
@@ -75,6 +76,7 @@ pub fn auth_for_backend(backend: Backend) -> Box<dyn Auth> {
         Backend::DuckDB => Box::new(duckdb::DuckDbAuth {}),
         Backend::SQLServer => Box::new(sqlserver::SQLServerAuth {}),
         Backend::ClickHouse => Box::new(clickhouse::ClickHouseAuth {}),
+        Backend::Exasol => Box::new(exasol::ExasolAuth {}),
         Backend::Generic { .. } => unimplemented!("generic backend authentication"),
     }
 }

--- a/crates/dbt-df-providers/src/listing_table.rs
+++ b/crates/dbt-df-providers/src/listing_table.rs
@@ -115,6 +115,7 @@ pub fn infer_seed_column_name_strategy(
             | AdapterType::Sidecar,
         ) => InferColumnNameStrategy::Verbatim,
         (false, AdapterType::ClickHouse) => todo!("ClickHouse"),
+        (false, AdapterType::Exasol) => todo!("Exasol"),
         (false, AdapterType::Starburst) => todo!("Starburst"),
         (false, AdapterType::Athena) => todo!("Athena"),
         (false, AdapterType::Trino) => todo!("Trino"),

--- a/crates/dbt-init/src/profile_setup.rs
+++ b/crates/dbt-init/src/profile_setup.rs
@@ -262,6 +262,7 @@ impl ProfileSetup {
                 ));
             }
             AdapterType::ClickHouse => todo!("ClickHouse"),
+            AdapterType::Exasol => todo!("Exasol"),
             AdapterType::Starburst => todo!("Starburst"),
             AdapterType::Athena => todo!("Athena"),
             AdapterType::Trino => todo!("Trino"),

--- a/crates/dbt-schemas/src/schemas/profiles.rs
+++ b/crates/dbt-schemas/src/schemas/profiles.rs
@@ -50,7 +50,7 @@ pub enum DbConfig {
     Salesforce(Box<SalesforceDbConfig>),
     DuckDB(Box<DuckDbConfig>),
     // Hive,
-    // Exasol,
+    // Exasol, // TODO: add ExasolDbConfig when profile schema is defined
     // Oracle,
     // Synapse,
     Fabric(Box<FabricDbConfig>),

--- a/crates/dbt-schemas/src/schemas/relations/base.rs
+++ b/crates/dbt-schemas/src/schemas/relations/base.rs
@@ -586,6 +586,7 @@ pub trait BaseRelation: BaseRelationProperties + Any + Send + Sync + fmt::Debug 
                 end.map(|end| format!("{event_time} < '{end}'")),
             ),
             AdapterType::ClickHouse => todo!("ClickHouse"),
+            AdapterType::Exasol => todo!("Exasol"),
             AdapterType::Starburst => todo!("Starburst"),
             AdapterType::Athena => todo!("Athena"),
             AdapterType::Trino => todo!("Trino"),

--- a/crates/dbt-xdbc/src/driver.rs
+++ b/crates/dbt-xdbc/src/driver.rs
@@ -73,6 +73,8 @@ pub enum Backend {
     SQLServer,
     /// ClickHouse driver implementation (ADBC).
     ClickHouse,
+    /// Exasol driver implementation (ADBC).
+    Exasol,
     /// Databricks driver implementation (ODBC).
     DatabricksODBC,
     /// Redshift driver implementation (ODBC).
@@ -108,6 +110,7 @@ impl fmt::Display for Backend {
             Backend::Spark => write!(f, "Spark"),
             Backend::SQLServer => write!(f, "SQL Server"),
             Backend::ClickHouse => write!(f, "ClickHouse"),
+            Backend::Exasol => write!(f, "Exasol"),
             Backend::Generic { library_name, .. } => write!(f, "Generic({library_name})"),
         }
     }
@@ -127,6 +130,7 @@ impl Backend {
             Backend::SQLServer => Some("adbc_driver_mssql"),
             Backend::DatabricksODBC | Backend::RedshiftODBC => None, // these use ODBC
             Backend::ClickHouse => Some("adbc_clickhouse"),
+            Backend::Exasol => Some("adbc_driver_exasol"),
             Backend::Generic { library_name, .. } => Some(library_name),
         }
     }
@@ -155,6 +159,7 @@ impl Backend {
             | Backend::DuckDB
             | Backend::SQLServer
             | Backend::ClickHouse
+            | Backend::Exasol
             | Backend::Generic { .. } => FFIProtocol::Adbc,
             Backend::DatabricksODBC | Backend::RedshiftODBC => FFIProtocol::Odbc,
         }
@@ -429,7 +434,7 @@ impl AdbcDriver {
                 ));
             }
             // CDN strategy for non-CDN drivers: just fall back to the system strategy.
-            (CdnCache | SystemThenCdnCache | Remote, ClickHouse) => System(None),
+            (CdnCache | SystemThenCdnCache | Remote, ClickHouse | Exasol) => System(None),
             // Generic drivers can only be loaded from a file, so fallback to the System strategy.
             (CdnCache | SystemThenCdnCache | Remote, Generic { library_name, .. }) => {
                 System(Some(library_name.to_string()))

--- a/crates/dbt-xdbc/src/install.rs
+++ b/crates/dbt-xdbc/src/install.rs
@@ -314,6 +314,7 @@ pub fn driver_parameters(backend: Backend) -> (&'static str, DriverTriplet<'stat
         Backend::DuckDB => ("duckdb", DUCKDB_DRIVER_VERSION),
         Backend::SQLServer => ("mssql", MSSQLSERVER_DRIVER_VERSION),
         Backend::ClickHouse
+        | Backend::Exasol
         | Backend::DatabricksODBC
         | Backend::RedshiftODBC
         | Backend::Generic { .. } => {

--- a/crates/dbt-xdbc/src/lib.rs
+++ b/crates/dbt-xdbc/src/lib.rs
@@ -97,6 +97,7 @@ pub const DUCKDB_DRIVER_VERSION: &str = "0.21.0.dev+dbt0.0.12";
 pub const SALESFORCE_DRIVER_VERSION: &str = "0.21.0+dbt0.21.1";
 pub const SPARK_DRIVER_VERSION: &str = "0.21.0.dev+dbt0.1.0";
 pub const MSSQLSERVER_DRIVER_VERSION: &str = "1.3.1";
+pub const EXASOL_DRIVER_VERSION: &str = "0.9.0";
 
 pub use install::pre_install_all_drivers;
 pub use install::pre_install_driver;

--- a/crates/dbt-xdbc/src/sql/ident.rs
+++ b/crates/dbt-xdbc/src/sql/ident.rs
@@ -124,7 +124,7 @@ pub const fn quote_char(backend: Backend) -> char {
     match backend {
         BigQuery | Databricks | DatabricksODBC | Spark => '`',
         Snowflake => '"',
-        ClickHouse | Redshift | RedshiftODBC | Postgres | Salesforce | DuckDB => '"',
+        ClickHouse | Exasol | Redshift | RedshiftODBC | Postgres | Salesforce | DuckDB => '"',
         // https://learn.microsoft.com/en-us/sql/t-sql/statements/set-quoted-identifier-transact-sql?view=sql-server-ver17
         SQLServer => '"',
         Generic { .. } => '"',
@@ -136,7 +136,7 @@ pub const fn canonical_quote(backend: Backend) -> QuotingStyle {
     use Backend::*;
     match backend {
         BigQuery | Databricks | DatabricksODBC | Spark => QuotingStyle::Backtick,
-        ClickHouse | Snowflake | Redshift | RedshiftODBC | Postgres | Salesforce | DuckDB => {
+        ClickHouse | Exasol | Snowflake | Redshift | RedshiftODBC | Postgres | Salesforce | DuckDB => {
             QuotingStyle::Double
         }
         // https://learn.microsoft.com/en-us/sql/t-sql/statements/set-quoted-identifier-transact-sql?view=sql-server-ver17
@@ -169,6 +169,7 @@ pub fn is_valid_ident_char(c: char, backend: Backend) -> bool {
         | DuckDB
         | SQLServer // TODO
         | ClickHouse
+        | Exasol
         | Generic { .. } => c.is_alphanumeric() || c == '_',
     }
 }

--- a/crates/dbt-xdbc/src/sql/keywords.rs
+++ b/crates/dbt-xdbc/src/sql/keywords.rs
@@ -20,6 +20,7 @@ pub fn sorted_keywords_for(backend: Backend) -> &'static [&'static str] {
         | Salesforce
         | SQLServer
         | ClickHouse
+        | Exasol
         | Generic { .. } => &[],
     }
 }

--- a/crates/dbt-xdbc/src/sql/types/mod.rs
+++ b/crates/dbt-xdbc/src/sql/types/mod.rs
@@ -104,6 +104,7 @@ impl fmt::Display for TimeZoneDisplay<'_> {
         match (self.1, self.0) {
             // https://clickhouse.com/docs/use-cases/time-series/date-time-data-types#time-series-timezones
             (ClickHouse, Named(name)) => write!(f, "'{name}'")?,
+            (Exasol, Named(name)) => write!(f, "'{name}'")?,
 
             (_, Named(name)) => write!(f, "{name}")?,
         }
@@ -165,6 +166,13 @@ impl TimeZoneSpec {
                 debug_assert!(
                     matches!(self, Without | Unspecified),
                     "BigQuery and ClickHouse do not support time zone suffixes in their type names"
+                );
+                Ok(())
+            }
+            (Exasol, _) => {
+                debug_assert!(
+                    matches!(self, Without | Unspecified),
+                    "Exasol does not support time zone suffixes in type names"
                 );
                 Ok(())
             }
@@ -252,6 +260,7 @@ pub fn default_time_unit(backend: Backend) -> TimeUnit {
         Postgres | Salesforce | DuckDB => Microsecond,
         SQLServer => Microsecond,
         ClickHouse => Second,
+        Exasol => Millisecond,
         Generic { .. } => Microsecond, // a reasonable default
     }
 }
@@ -759,7 +768,7 @@ impl SqlType {
                 match backend {
                     Snowflake => write!(out, "OBJECT(")?,
                     BigQuery | Databricks | DatabricksODBC | Spark => write!(out, "STRUCT<")?,
-                    Postgres | Salesforce | DuckDB | ClickHouse => write!(out, "(")?,
+                    Postgres | Salesforce | DuckDB | ClickHouse | Exasol => write!(out, "(")?,
                     // Redshift doesn't support object/struct types
                     Redshift | RedshiftODBC => write!(out, "(")?,
                     SQLServer => unimplemented!("SQL Server does't have a struct type"),
@@ -798,7 +807,7 @@ impl SqlType {
                 match backend {
                     Snowflake => write!(out, ")"),
                     BigQuery | Databricks | DatabricksODBC | Spark => write!(out, ">"),
-                    Postgres | Salesforce | DuckDB | ClickHouse => write!(out, ")"),
+                    Postgres | Salesforce | DuckDB | ClickHouse | Exasol => write!(out, ")"),
                     Redshift | RedshiftODBC => write!(out, ")"),
                     SQLServer => unimplemented!("SQL Server does't have a struct type"),
                     Generic { .. } => write!(out, ">"),
@@ -1208,6 +1217,10 @@ impl SqlType {
                 // https://clickhouse.com/docs/sql-reference/data-types/decimal#parameters
                 DataType::Decimal128(10, 0)
             }
+            (Exasol, Numeric(None) | BigNumeric(None)) => {
+                // Exasol default: DECIMAL(18, 0)
+                DataType::Decimal128(18, 0)
+            }
             // }}}
 
             // PostgreSQL {{{
@@ -1301,6 +1314,7 @@ impl SqlType {
                     // `Time64` has adjustable precision:
                     // https://clickhouse.com/docs/sql-reference/data-types/time64
                     (ClickHouse, None) => TimeUnit::Second,
+                    (Exasol, None) => TimeUnit::Millisecond,
                     (Generic { .. }, None) => {
                         // we pick microseconds as a reasonable default
                         TimeUnit::Microsecond
@@ -1450,6 +1464,7 @@ impl SqlType {
                     BigQuery | Postgres | DuckDB => MonthDayNano, // MonthDayNano is exactly what BQ and PG use internally
                     // FIXME: ClickHouse doesn't actually seem to support Arrow's Interval
                     ClickHouse => MonthDayNano,
+                    Exasol => MonthDayNano,
                     Salesforce => MonthDayNano, // Salesforce seems to follow PostgreSQL
                     SQLServer => MonthDayNano, // SQL Server doesn't appear to have an INTERVAL type
                     Generic { .. } => MonthDayNano, // Reasonable default
@@ -1592,6 +1607,7 @@ const DATABRICKS_KEYS: [&str; 2] = ["DBX:type", "type_text"];
 const REDSHIFT_KEYS: [&str; 2] = ["REDSHIFT:type", "type_text"];
 const DUCKDB_KEYS: [&str; 2] = ["DUCKDB:type", "type_text"];
 const CLICKHOUSE_KEYS: [&str; 2] = ["CLICKHOUSE:type", "type_text"];
+const EXASOL_KEYS: [&str; 2] = ["EXASOL:type", "type_text"];
 const SPARK_KEYS: [&str; 2] = ["SPARK:type", "type_text"];
 const SQLSERVER_KEYS: [&str; 2] = ["SQLSERVER:type", "type_text"];
 const GENERIC_KEYS: [&str; 2] = ["SQL:type", "type_text"];
@@ -1608,6 +1624,7 @@ fn metadata_type_candidate_keys(backend: Backend) -> &'static [&'static str] {
         Backend::DuckDB => &DUCKDB_KEYS,
         Backend::SQLServer => &SQLSERVER_KEYS, // TODO
         Backend::ClickHouse => &CLICKHOUSE_KEYS,
+        Backend::Exasol => &EXASOL_KEYS,
         Backend::Generic { .. } => &GENERIC_KEYS,
     }
 }

--- a/crates/dbt-xdbc/src/sql/types/tests.rs
+++ b/crates/dbt-xdbc/src/sql/types/tests.rs
@@ -1081,6 +1081,7 @@ fn expected_type_rendering_for(backend: Backend) -> Vec<(u32, SqlType, &'static 
                 Databricks | DatabricksODBC => dbx,
                 DuckDB => todo!("DuckDB tests not implemented yet"),
                 ClickHouse => todo!("ClickHouse tests not implemented yet"),
+                Exasol => todo!("Exasol tests not implemented yet"),
                 Spark => todo!("Spark tests not implemented yet"),
                 SQLServer => todo!("SQL Server tests not implemented yet"),
                 Generic { .. } => generic,

--- a/crates/dbt-xdbc/tests/driver/mod.rs
+++ b/crates/dbt-xdbc/tests/driver/mod.rs
@@ -180,6 +180,30 @@ mod tests {
                     .with_password(password);
                 Ok(builder)
             }
+            Backend::Exasol => {
+                let mut builder = database::Builder::new(backend);
+                let uri = env::var("ADBC_EXASOL_URI")
+                    .unwrap_or_else(|_| "exasol://localhost:8563".to_owned());
+                let username =
+                    env::var("ADBC_EXASOL_USERNAME").unwrap_or_else(|_| "sys".to_owned());
+                let password =
+                    env::var("ADBC_EXASOL_PASSWORD").unwrap_or_else(|_| "exasol".to_owned());
+                let validate_cert = env::var("ADBC_EXASOL_VALIDATE_CERT")
+                    .unwrap_or_else(|_| "0".to_owned());
+                // Append certificate validation param if not already in URI
+                let uri = if uri.contains("validateservercertificate") {
+                    uri
+                } else if uri.contains('?') {
+                    format!("{uri}&validateservercertificate={validate_cert}")
+                } else {
+                    format!("{uri}?validateservercertificate={validate_cert}")
+                };
+                builder
+                    .with_parse_uri(uri)?
+                    .with_username(username)
+                    .with_password(password);
+                Ok(builder)
+            }
             Backend::Generic { .. } => unimplemented!("generic backend database builder in tests"),
         }?;
         if backend == Backend::Snowflake {
@@ -303,6 +327,13 @@ mod tests {
                 }
                 Backend::ClickHouse => {
                     assert_eq!(batch.column(0).as_primitive::<UInt16Type>().value(0), 42);
+                }
+                Backend::Exasol => {
+                    // Exasol returns DECIMAL for integer arithmetic
+                    assert_eq!(
+                        batch.column(0).as_primitive::<Decimal128Type>().value(0),
+                        42
+                    );
                 }
                 _ => {
                     // BigQuery and others use Int64. We change this function as we expand the set
@@ -1150,5 +1181,11 @@ mod tests {
     #[test]
     fn statement_execute_clickhouse() -> Result<()> {
         execute_statement(Backend::ClickHouse)
+    }
+
+    #[test_with::env(ADBC_EXASOL_URI)]
+    #[test]
+    fn statement_execute_exasol() -> Result<()> {
+        execute_statement(Backend::Exasol)
     }
 }


### PR DESCRIPTION
This PR adds Exasol database support to dbt-fusion (I am working at [Exasol](https://exasol.com)). The connector uses [exasol-labs/exarrow-rs](https://github.com/exasol-labs/exarrow-rs) (v0.9.0), an ADBC-compatible driver for Exasol with Apache Arrow data format support, maintained by [Exasol](https://www.exasol.com/).

[exarrow-rs](https://github.com/exasol-labs/exarrow-rs) is part of the [ADBC Driver Foundry](https://adbc-drivers.org) and can be installed via `dbc install exasol`. Foundry repo is here [adbc-drivers/exasol](https://github.com/adbc-drivers/exasol)

- **Auth module** (`dbt-auth`): Username/password authentication with TLS encryption, certificate validation toggle, certificate fingerprint pinning, and connection timeout support. Profile keys: `host`, `port`, `user`, `password`, `schema`, `encryption`, `certificate_validation`, `certificate_fingerprint`, `connection_timeout`.
- **Backend & adapter wiring**: `Backend::Exasol` and `AdapterType::Exasol` added as independent variants across all match arms in dbt-xdbc, dbt-adapter, dbt-schemas, dbt-init, and dbt-df-providers.
- **Driver loading**: Uses `adbc_driver_exasol` library with standard `AdbcDriverInit` entrypoint. Installable via `dbc install exasol`.
- **Integration test**: `statement_execute_exasol` gated by `ADBC_EXASOL_URI` env var, verified against Exasol Docker.

This PR is created in collaboration with Claude Code. The PR is raised on behalf of Exasol.